### PR TITLE
Feature/19 커뮤니티 게시글 조회 기능

### DIFF
--- a/src/main/java/com/somemore/center/dto/response/CenterForCommunityResponseDto.java
+++ b/src/main/java/com/somemore/center/dto/response/CenterForCommunityResponseDto.java
@@ -1,0 +1,28 @@
+package com.somemore.center.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.center.domain.Center;
+import com.somemore.community.dto.response.WriterDetailDto;
+import com.somemore.volunteer.domain.Tier;
+
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CenterForCommunityResponseDto(
+        UUID id,
+        String name,
+        String imgUrl,
+        Tier tier
+) implements WriterDetailDto {
+
+    public static CenterForCommunityResponseDto fromEntity(Center center) {
+        return new CenterForCommunityResponseDto(
+                center.getId(),
+                center.getName(),
+                center.getImgUrl(),
+                null
+        );
+    }
+}
+

--- a/src/main/java/com/somemore/center/repository/CenterJpaRepository.java
+++ b/src/main/java/com/somemore/center/repository/CenterJpaRepository.java
@@ -1,0 +1,12 @@
+package com.somemore.center.repository;
+
+import com.somemore.center.domain.Center;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CenterJpaRepository extends JpaRepository<Center, Long> {
+    boolean existsById(UUID id);
+    Optional<Center> findCenterById(UUID id);
+}

--- a/src/main/java/com/somemore/center/repository/CenterRepository.java
+++ b/src/main/java/com/somemore/center/repository/CenterRepository.java
@@ -1,20 +1,19 @@
 package com.somemore.center.repository;
 
 import com.somemore.center.domain.Center;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface CenterRepository extends JpaRepository<Center, UUID> {
-
+public interface CenterRepository {
+    Center save(Center center);
     boolean existsById(UUID id);
-
     default boolean doesNotExistById(UUID id) {
         return !existsById(id);
     }
-
     Optional<Center> findCenterById(UUID id);
+    String findNameById(UUID id);
+    void deleteAllInBatch();
 }

--- a/src/main/java/com/somemore/center/repository/CenterRepositoryImpl.java
+++ b/src/main/java/com/somemore/center/repository/CenterRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.somemore.center.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.somemore.center.domain.Center;
+import com.somemore.center.domain.QCenter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class CenterRepositoryImpl implements CenterRepository {
+
+    private final CenterJpaRepository centerJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Center save(Center center) {
+        return centerJpaRepository.save(center);
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return centerJpaRepository.existsById(id);
+    }
+
+    @Override
+    public Optional<Center> findCenterById(UUID id) {
+        return centerJpaRepository.findCenterById(id);
+    }
+
+    @Override
+    public String findNameById(UUID id) {
+        QCenter center = QCenter.center;
+
+        return queryFactory
+                .select(center.name)
+                .from(center)
+                .where(center.id.eq(id))
+                .fetchOne();
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        centerJpaRepository.deleteAllInBatch();
+    }
+}

--- a/src/main/java/com/somemore/center/service/query/CenterQueryService.java
+++ b/src/main/java/com/somemore/center/service/query/CenterQueryService.java
@@ -1,6 +1,7 @@
 package com.somemore.center.service.query;
 
 import com.somemore.center.domain.Center;
+import com.somemore.center.dto.response.CenterForCommunityResponseDto;
 import com.somemore.center.dto.response.CenterProfileResponseDto;
 import com.somemore.center.dto.response.PreferItemResponseDto;
 import com.somemore.center.repository.CenterRepository;
@@ -45,4 +46,14 @@ public class CenterQueryService implements CenterQueryUseCase {
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTS_CENTER.getMessage()));
     }
 
+    @Override
+    public String getNameById(UUID id) {
+        return centerRepository.findNameById(id);
+    }
+
+    @Override
+    public CenterForCommunityResponseDto getCenterDetailForCommunity(UUID id) {
+        Center center = getCenterById(id);
+        return CenterForCommunityResponseDto.fromEntity(center);
+    }
 }

--- a/src/main/java/com/somemore/center/usecase/query/CenterQueryUseCase.java
+++ b/src/main/java/com/somemore/center/usecase/query/CenterQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.somemore.center.usecase.query;
 
+import com.somemore.center.dto.response.CenterForCommunityResponseDto;
 import com.somemore.center.dto.response.CenterProfileResponseDto;
 
 import java.util.UUID;
@@ -8,4 +9,6 @@ public interface CenterQueryUseCase {
 
     CenterProfileResponseDto getCenterProfileByCenterId(UUID centerId);
     void validateCenterExists(UUID centerId);
+    String getNameById(UUID id);
+    CenterForCommunityResponseDto getCenterDetailForCommunity(UUID id);
 }

--- a/src/main/java/com/somemore/community/dto/response/CommunityBoardGetDetailResponseDto.java
+++ b/src/main/java/com/somemore/community/dto/response/CommunityBoardGetDetailResponseDto.java
@@ -1,0 +1,30 @@
+package com.somemore.community.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.community.domain.CommunityBoard;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CommunityBoardGetDetailResponseDto(
+        Long id,
+        String title,
+        String content,
+        String imageUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        WriterDetailDto writerDetailDto
+) {
+    public static CommunityBoardGetDetailResponseDto fromEntity(CommunityBoard board, WriterDetailDto writer) {
+        return new CommunityBoardGetDetailResponseDto(
+                board.getId(),
+                board.getTitle(),
+                board.getContent(),
+                board.getImgUrl(),
+                board.getCreatedAt(),
+                board.getUpdatedAt(),
+                writer
+        );
+    }
+}

--- a/src/main/java/com/somemore/community/dto/response/CommunityBoardGetResponseDto.java
+++ b/src/main/java/com/somemore/community/dto/response/CommunityBoardGetResponseDto.java
@@ -1,0 +1,25 @@
+package com.somemore.community.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.community.domain.CommunityBoard;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record CommunityBoardGetResponseDto(
+        Long id,
+        String title,
+        String writerNickname,
+        LocalDateTime createdAt
+) {
+    public static CommunityBoardGetResponseDto fromEntity(CommunityBoard board, String writerNickname) {
+        return new CommunityBoardGetResponseDto(
+                board.getId(),
+                board.getTitle(),
+                writerNickname,
+                board.getCreatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/somemore/community/dto/response/WriterDetailDto.java
+++ b/src/main/java/com/somemore/community/dto/response/WriterDetailDto.java
@@ -1,0 +1,12 @@
+package com.somemore.community.dto.response;
+
+import com.somemore.volunteer.domain.Tier;
+
+import java.util.UUID;
+
+public interface WriterDetailDto {
+    UUID id();
+    String name();
+    String imgUrl();
+    Tier tier();
+}

--- a/src/main/java/com/somemore/community/repository/CommunityBoardJpaRepository.java
+++ b/src/main/java/com/somemore/community/repository/CommunityBoardJpaRepository.java
@@ -1,0 +1,7 @@
+package com.somemore.community.repository;
+
+import com.somemore.community.domain.CommunityBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityBoardJpaRepository extends JpaRepository<CommunityBoard, Long> {
+}

--- a/src/main/java/com/somemore/community/repository/CommunityBoardRepository.java
+++ b/src/main/java/com/somemore/community/repository/CommunityBoardRepository.java
@@ -1,8 +1,15 @@
 package com.somemore.community.repository;
 
 import com.somemore.community.domain.CommunityBoard;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommunityBoardRepository extends JpaRepository<CommunityBoard, Long> {
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
+public interface CommunityBoardRepository {
+    CommunityBoard save(CommunityBoard communityBoard);
+    Optional<CommunityBoard> findById(Long id);
+    List<CommunityBoard> getCommunityBoards();
+    List<CommunityBoard> getCommunityBoardsByWriterId(UUID writerId);
+    void deleteAllInBatch();
 }

--- a/src/main/java/com/somemore/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/com/somemore/community/repository/CommunityRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.somemore.community.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.domain.QCommunityBoard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class CommunityRepositoryImpl implements CommunityBoardRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final CommunityBoardJpaRepository communityBoardJpaRepository;
+
+    @Override
+    public CommunityBoard save(CommunityBoard communityBoard) {
+        return communityBoardJpaRepository.save(communityBoard);
+    }
+
+    @Override
+    public Optional<CommunityBoard> findById(Long id) {
+        return communityBoardJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<CommunityBoard> getCommunityBoards() {
+        QCommunityBoard communityBoard = QCommunityBoard.communityBoard;
+
+        return queryFactory
+                .selectFrom(communityBoard)
+                .where(communityBoard.deleted.eq(false))
+                .orderBy(communityBoard.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<CommunityBoard> getCommunityBoardsByWriterId(UUID writerId) {
+        QCommunityBoard communityBoard = QCommunityBoard.communityBoard;
+
+        return queryFactory
+                .selectFrom(communityBoard)
+                .where(communityBoard.writerId.eq(writerId)
+                        .and(communityBoard.deleted.eq(false))
+                )
+                .orderBy(communityBoard.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        communityBoardJpaRepository.deleteAllInBatch();
+    }
+}

--- a/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
+++ b/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNITY_BOARD;
 
@@ -66,7 +65,6 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
         if (nickname == null) {
             nickname = centerQueryUseCase.getNameById(writerId);
         }
-
         return nickname;
     }
 
@@ -75,8 +73,7 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
 
         if (volunteer == null) {
             return centerQueryUseCase.getCenterDetailForCommunity(writerId);
-        } else {
-            return volunteer;
         }
+        return volunteer;
     }
 }

--- a/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
+++ b/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
@@ -39,7 +39,7 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
                     String writerNickname = getWriterNickname(board.getWriterId());
                     return CommunityBoardGetResponseDto.fromEntity(board, writerNickname);
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override
@@ -49,7 +49,7 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
 
         return boards.stream()
                 .map(board -> CommunityBoardGetResponseDto.fromEntity(board, writerNickname))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
+++ b/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
@@ -1,0 +1,82 @@
+package com.somemore.community.service.query;
+
+import com.somemore.center.usecase.query.CenterQueryUseCase;
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.dto.response.CommunityBoardGetDetailResponseDto;
+import com.somemore.community.dto.response.CommunityBoardGetResponseDto;
+import com.somemore.community.dto.response.WriterDetailDto;
+import com.somemore.community.repository.CommunityBoardRepository;
+import com.somemore.community.usecase.query.CommunityBoardQueryUseCase;
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.volunteer.dto.response.VolunteerForCommunityResponseDto;
+import com.somemore.volunteer.usecase.query.FindVolunteerIdUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNITY_BOARD;
+
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
+
+    private final CommunityBoardRepository communityBoardRepository;
+    private final CenterQueryUseCase centerQueryUseCase;
+    private final FindVolunteerIdUseCase findVolunteerIdUseCase;
+
+    @Override
+    public List<CommunityBoardGetResponseDto> getCommunityBoards() {
+        List<CommunityBoard> boards = communityBoardRepository.getCommunityBoards();
+
+        return boards.stream()
+                .map(board -> {
+                    String writerNickname = getWriterNickname(board.getWriterId());
+                    return CommunityBoardGetResponseDto.fromEntity(board, writerNickname);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CommunityBoardGetResponseDto> getCommunityBoardsByWriterId(UUID writerId) {
+        List<CommunityBoard> boards = communityBoardRepository.getCommunityBoardsByWriterId(writerId);
+        String writerNickname = getWriterNickname(writerId);
+
+        return boards.stream()
+                .map(board -> CommunityBoardGetResponseDto.fromEntity(board, writerNickname))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public CommunityBoardGetDetailResponseDto getCommunityBoardDetail(Long id) {
+        CommunityBoard board = communityBoardRepository.findById(id)
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTS_COMMUNITY_BOARD.getMessage()));
+
+        return CommunityBoardGetDetailResponseDto.fromEntity(board, getWriterDetail(board.getWriterId()));
+    }
+
+    private String getWriterNickname(UUID writerId) {
+        String nickname = findVolunteerIdUseCase.getNicknameById(writerId);
+
+        if (nickname == null) {
+            nickname = centerQueryUseCase.getNameById(writerId);
+        }
+
+        return nickname;
+    }
+
+    private WriterDetailDto getWriterDetail(UUID writerId) {
+        VolunteerForCommunityResponseDto volunteer = findVolunteerIdUseCase.getVolunteerDetailForCommunity(writerId);
+
+        if (volunteer == null) {
+            return centerQueryUseCase.getCenterDetailForCommunity(writerId);
+        } else {
+            return volunteer;
+        }
+    }
+}

--- a/src/main/java/com/somemore/community/usecase/query/CommunityBoardQueryUseCase.java
+++ b/src/main/java/com/somemore/community/usecase/query/CommunityBoardQueryUseCase.java
@@ -1,0 +1,13 @@
+package com.somemore.community.usecase.query;
+
+import com.somemore.community.dto.response.CommunityBoardGetDetailResponseDto;
+import com.somemore.community.dto.response.CommunityBoardGetResponseDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CommunityBoardQueryUseCase {
+    List<CommunityBoardGetResponseDto> getCommunityBoards();
+    List<CommunityBoardGetResponseDto> getCommunityBoardsByWriterId(UUID writerId);
+    CommunityBoardGetDetailResponseDto getCommunityBoardDetail(Long id);
+}

--- a/src/main/java/com/somemore/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/somemore/global/exception/ExceptionMessage.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionMessage {
 
-    NOT_EXISTS_CENTER("존재하지 않는 기관 ID 입니다.")
+    NOT_EXISTS_CENTER("존재하지 않는 기관 ID 입니다."),
+    NOT_EXISTS_COMMUNITY_BOARD("삭제된 게시글 입니다.")
     ;
 
     private final String message;

--- a/src/main/java/com/somemore/volunteer/dto/response/VolunteerForCommunityResponseDto.java
+++ b/src/main/java/com/somemore/volunteer/dto/response/VolunteerForCommunityResponseDto.java
@@ -1,0 +1,28 @@
+package com.somemore.volunteer.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.community.dto.response.WriterDetailDto;
+import com.somemore.volunteer.domain.Tier;
+import com.somemore.volunteer.domain.Volunteer;
+
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record VolunteerForCommunityResponseDto(
+        UUID id,
+        String name,
+        String imgUrl,
+        Tier tier
+) implements WriterDetailDto {
+
+    public static VolunteerForCommunityResponseDto fromEntity(Volunteer volunteer) {
+        return new VolunteerForCommunityResponseDto(
+                volunteer.getId(),
+                volunteer.getNickname(),
+                volunteer.getImgUrl(),
+                volunteer.getTier()
+        );
+    }
+}
+

--- a/src/main/java/com/somemore/volunteer/repository/VolunteerJpaRepository.java
+++ b/src/main/java/com/somemore/volunteer/repository/VolunteerJpaRepository.java
@@ -1,16 +1,12 @@
 package com.somemore.volunteer.repository;
 
 import com.somemore.volunteer.domain.Volunteer;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
-@Repository
-public interface VolunteerRepository {
-    Volunteer save(Volunteer volunteer);
+public interface VolunteerJpaRepository extends JpaRepository<Volunteer, Long> {
     Volunteer findById(UUID id);
-    String findNicknameById(UUID id);
     Optional<Volunteer> findByOauthId(String oauthId);
-    void deleteAllInBatch();
 }

--- a/src/main/java/com/somemore/volunteer/repository/VolunteerRepositoryImpl.java
+++ b/src/main/java/com/somemore/volunteer/repository/VolunteerRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.somemore.volunteer.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.somemore.volunteer.domain.QVolunteer;
+import com.somemore.volunteer.domain.Volunteer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class VolunteerRepositoryImpl implements VolunteerRepository{
+
+    private final VolunteerJpaRepository volunteerJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Volunteer save(Volunteer volunteer) {
+        return volunteerJpaRepository.save(volunteer);
+    }
+
+    @Override
+    public Volunteer findById(UUID id) {
+        return volunteerJpaRepository.findById(id);
+    }
+
+    @Override
+    public String findNicknameById(UUID id) {
+        QVolunteer volunteer = QVolunteer.volunteer;
+
+        return queryFactory
+                .select(volunteer.nickname)
+                .from(volunteer)
+                .where(volunteer.id.eq(id))
+                .fetchOne();
+    }
+
+    @Override
+    public Optional<Volunteer> findByOauthId(String oauthId) {
+        return volunteerJpaRepository.findByOauthId(oauthId);
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        volunteerJpaRepository.deleteAllInBatch();
+    }
+}

--- a/src/main/java/com/somemore/volunteer/service/query/FindVolunteerIdService.java
+++ b/src/main/java/com/somemore/volunteer/service/query/FindVolunteerIdService.java
@@ -1,5 +1,7 @@
 package com.somemore.volunteer.service.query;
 
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.dto.response.VolunteerForCommunityResponseDto;
 import com.somemore.volunteer.repository.VolunteerRepository;
 import com.somemore.volunteer.usecase.query.FindVolunteerIdUseCase;
 import jakarta.persistence.EntityNotFoundException;
@@ -23,5 +25,17 @@ public class FindVolunteerIdService implements FindVolunteerIdUseCase {
         return volunteerRepository.findByOauthId(oAuthId)
                 .orElseThrow(EntityNotFoundException::new)
                 .getId();
+    }
+
+    @Override
+    public String getNicknameById(UUID id) {
+        return volunteerRepository.findNicknameById(id);
+    }
+
+    @Override
+    public VolunteerForCommunityResponseDto getVolunteerDetailForCommunity(UUID id) {
+        Volunteer volunteer = volunteerRepository.findById(id);
+
+        return VolunteerForCommunityResponseDto.fromEntity(volunteer);
     }
 }

--- a/src/main/java/com/somemore/volunteer/usecase/query/FindVolunteerIdUseCase.java
+++ b/src/main/java/com/somemore/volunteer/usecase/query/FindVolunteerIdUseCase.java
@@ -1,7 +1,11 @@
 package com.somemore.volunteer.usecase.query;
 
+import com.somemore.volunteer.dto.response.VolunteerForCommunityResponseDto;
+
 import java.util.UUID;
 
 public interface FindVolunteerIdUseCase {
     UUID findVolunteerIdByOAuthId(String oAuthId);
+    String getNicknameById(UUID id);
+    VolunteerForCommunityResponseDto getVolunteerDetailForCommunity(UUID id);
 }

--- a/src/test/java/com/somemore/center/repository/CenterRepositoryTest.java
+++ b/src/test/java/com/somemore/center/repository/CenterRepositoryTest.java
@@ -82,4 +82,25 @@ class CenterRepositoryTest extends IntegrationTestSupport {
         assertThat(isExist).isFalse();
     }
 
+    @DisplayName("센터의 id로 name을 조회한다. (Repository)")
+    @Test
+    void findNameById() {
+        //given
+        Center center = Center.create(
+                "기본 기관 이름",
+                "010-1234-5678",
+                "http://example.com/image.jpg",
+                "기관 소개 내용",
+                "http://example.com",
+                "account123",
+                "password123"
+        );
+        centerRepository.save(center);
+
+        //when
+        String centerName = centerRepository.findNameById(center.getId());
+
+        //then
+        assertThat(centerName).isEqualTo("기본 기관 이름");
+    }
 }

--- a/src/test/java/com/somemore/center/service/query/CenterQueryServiceTest.java
+++ b/src/test/java/com/somemore/center/service/query/CenterQueryServiceTest.java
@@ -119,4 +119,29 @@ class CenterQueryServiceTest extends IntegrationTestSupport {
         assertThatCode(callable).doesNotThrowAnyException();
     }
 
+    @DisplayName("센터의 id로 name을 조회한다.")
+    @Test
+    void getNameById() {
+
+        //given
+        Center center = Center.create(
+                "기본 기관 이름",
+                "010-1234-5678",
+                "http://example.com/image.jpg",
+                "기관 소개 내용",
+                "http://example.com",
+                "account123",
+                "password123"
+        );
+
+        Center savedCenter = centerRepository.save(center);
+
+        //when
+        String name = centerQueryService.getNameById(savedCenter.getId());
+
+        //then
+        assertThat(name).isEqualTo("기본 기관 이름");
+
+    }
+
 }

--- a/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
@@ -11,11 +11,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
-public class CommunityRepositoryTest extends IntegrationTestSupport {
+class CommunityRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private CommunityBoardRepository communityBoardRepository;
@@ -69,7 +68,7 @@ public class CommunityRepositoryTest extends IntegrationTestSupport {
         List<CommunityBoard> communityBoards = communityBoardRepository.getCommunityBoards();
 
         //then
-        assertThat(communityBoards.size()).isEqualTo(2);
+        assertThat(communityBoards).hasSize(2);
         assertThat(communityBoards.get(0)).isEqualTo(communityBoard2);
         assertThat(communityBoards.get(1)).isEqualTo(communityBoard1);
     }
@@ -107,7 +106,7 @@ public class CommunityRepositoryTest extends IntegrationTestSupport {
         List<CommunityBoard> communityBoards = communityBoardRepository.getCommunityBoardsByWriterId(communityBoard1.getWriterId());
 
         //then
-        assertThat(communityBoards.size()).isEqualTo(2);
+        assertThat(communityBoards).hasSize(2);
         assertThat(communityBoards.get(0)).isEqualTo(communityBoard2);
         assertThat(communityBoards.get(1)).isEqualTo(communityBoard1);
     }

--- a/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.somemore.community.repository;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.community.domain.CommunityBoard;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@Transactional
+public class CommunityRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CommunityBoardRepository communityBoardRepository;
+
+    @DisplayName("커뮤니티 id로 커뮤니티 상세 정보를 조회할 수 있다. (Repository)")
+    @Test
+    void findById() {
+        //given
+        CommunityBoard communityBoard = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목")
+                .content("테스트 커뮤니티 게시글 내용")
+                .imgUrl("http://community.example.com/123")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        communityBoardRepository.save(communityBoard);
+
+        //when
+        Optional<CommunityBoard> foundCommunityBoard = communityBoardRepository.findById(communityBoard.getId());
+
+        //then
+        assertThat(foundCommunityBoard).isNotNull();
+        assertThat(foundCommunityBoard.get().getTitle()).isEqualTo("테스트 커뮤니티 게시글 제목");
+        assertThat(foundCommunityBoard.get().getContent()).isEqualTo("테스트 커뮤니티 게시글 내용");
+        assertThat(foundCommunityBoard.get().getImgUrl()).isEqualTo("http://community.example.com/123");
+        assertThat(foundCommunityBoard.get().getWriterId()).isEqualTo(communityBoard.getWriterId());
+    }
+
+    @DisplayName("저장된 전체 커뮤니티 게시글을 목록으로 조회할 수 있다. (Repository)")
+    @Test
+    void getCommunityBoards() {
+        //given
+        CommunityBoard communityBoard1 = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목1")
+                .content("테스트 커뮤니티 게시글 내용1")
+                .imgUrl("http://community.example.com/123")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        CommunityBoard communityBoard2 = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목2")
+                .content("테스트 커뮤니티 게시글 내용2")
+                .imgUrl("http://community.example.com/12")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        communityBoardRepository.save(communityBoard1);
+        communityBoardRepository.save(communityBoard2);
+
+        //when
+        List<CommunityBoard> communityBoards = communityBoardRepository.getCommunityBoards();
+
+        //then
+        assertThat(communityBoards.size()).isEqualTo(2);
+        assertThat(communityBoards.get(0)).isEqualTo(communityBoard2);
+        assertThat(communityBoards.get(1)).isEqualTo(communityBoard1);
+    }
+
+    @DisplayName("저장된 커뮤니티 게시글 리스트를 작성자별로 조회할 수 있다. (Repository)")
+    @Test
+    void getCommunityBoardsByWriterId() {
+        //given
+        CommunityBoard communityBoard1 = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목1")
+                .content("테스트 커뮤니티 게시글 내용1")
+                .imgUrl("http://community.example.com/123")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        CommunityBoard communityBoard2 = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목2")
+                .content("테스트 커뮤니티 게시글 내용2")
+                .imgUrl("http://community.example.com/12")
+                .writerId(communityBoard1.getWriterId())
+                .build();
+
+        CommunityBoard communityBoard3 = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목3")
+                .content("테스트 커뮤니티 게시글 내용3")
+                .imgUrl("http://community.example.com/1")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        communityBoardRepository.save(communityBoard1);
+        communityBoardRepository.save(communityBoard2);
+        communityBoardRepository.save(communityBoard3);
+
+        //when
+        List<CommunityBoard> communityBoards = communityBoardRepository.getCommunityBoardsByWriterId(communityBoard1.getWriterId());
+
+        //then
+        assertThat(communityBoards.size()).isEqualTo(2);
+        assertThat(communityBoards.get(0)).isEqualTo(communityBoard2);
+        assertThat(communityBoards.get(1)).isEqualTo(communityBoard1);
+    }
+}

--- a/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
@@ -1,0 +1,238 @@
+package com.somemore.community.service.query;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.auth.oauth.OAuthProvider;
+import com.somemore.center.domain.Center;
+import com.somemore.center.repository.CenterRepository;
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.dto.request.CommunityBoardCreateRequestDto;
+import com.somemore.community.dto.response.CommunityBoardGetDetailResponseDto;
+import com.somemore.community.dto.response.CommunityBoardGetResponseDto;
+import com.somemore.community.repository.CommunityBoardRepository;
+import com.somemore.community.service.command.CreateCommunityBoardService;
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.global.exception.ExceptionMessage;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    CommunityBoardRepository communityBoardRepository;
+    @Autowired
+    VolunteerRepository volunteerRepository;
+    @Autowired
+    CenterRepository centerRepository;
+    @Autowired
+    CreateCommunityBoardService createCommunityBoardService;
+    @Autowired
+    CommunityBoardQueryService communityBoardQueryService;
+
+    @AfterEach
+    void tearDown() {
+        communityBoardRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("저장된 커뮤니티 게시글 리스트를 조회한다.")
+    @Test
+    void getAllCommunityBoards() {
+
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+       Volunteer savedVolunteer = volunteerRepository.save(volunteer);
+
+        Center center = Center.create(
+                "기본 기관 이름",
+                "010-1234-5678",
+                "http://example.com/image.jpg",
+                "기관 소개 내용",
+                "http://example.com",
+                "account123",
+                "password123"
+        );
+        Center savedCenter = centerRepository.save(center);
+
+        CommunityBoardCreateRequestDto dto1 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목1")
+                .content("커뮤니티 테스트 내용1")
+                .build();
+
+        CommunityBoardCreateRequestDto dto2 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목2")
+                .content("커뮤니티 테스트 내용2")
+                .build();
+
+
+        String imgUrl1 = "https://image.test.url/123";
+
+        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedCenter.getId(), null);
+        Long communityId2 = createCommunityBoardService.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
+
+        // when
+        List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoards();
+
+        // then
+        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
+        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
+
+        assertThat(dtos).isNotNull();
+        assertThat(dtos).hasSize(2);
+
+        CommunityBoardGetResponseDto board1 = dtos.getLast();
+        assertThat(board1.id()).isEqualTo(communityId1);
+        assertThat(board1.writerNickname()).isEqualTo(savedCenter.getName());
+        assertThat(board1.title()).isEqualTo(dto1.title());
+        assertThat(board1.createdAt()).isEqualTo(communityBoard1.get().getCreatedAt());
+
+        CommunityBoardGetResponseDto board2 = dtos.getFirst();
+        assertThat(board2.id()).isEqualTo(communityId2);
+        assertThat(board2.writerNickname()).isEqualTo(savedVolunteer.getNickname());
+        assertThat(board2.title()).isEqualTo(dto2.title());
+        assertThat(board2.createdAt()).isEqualTo(communityBoard2.get().getCreatedAt());
+    }
+
+    @DisplayName("저장된 커뮤니티 게시글 리스트를 작성자자별로 조회한다.")
+    @Test
+    void getCommunityBoardsByWriter() {
+
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+        Volunteer savedVolunteer = volunteerRepository.save(volunteer);
+
+        Center center = Center.create(
+                "기본 기관 이름",
+                "010-1234-5678",
+                "http://example.com/image.jpg",
+                "기관 소개 내용",
+                "http://example.com",
+                "account123",
+                "password123"
+        );
+        Center savedCenter = centerRepository.save(center);
+
+        CommunityBoardCreateRequestDto dto1 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목1")
+                .content("커뮤니티 테스트 내용1")
+                .build();
+
+        CommunityBoardCreateRequestDto dto2 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목2")
+                .content("커뮤니티 테스트 내용2")
+                .build();
+
+        CommunityBoardCreateRequestDto dto3 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목3")
+                .content("커뮤니티 테스트 내용23")
+                .build();
+
+        String imgUrl1 = "https://image.test.url/123";
+
+        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), null);
+        Long communityId2 = createCommunityBoardService.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
+        Long communityId3 = createCommunityBoardService.createCommunityBoard(dto3, savedCenter.getId(), imgUrl1);
+
+        //when
+        List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoardsByWriterId(volunteer.getId());
+
+        //then
+        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
+        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
+
+        assertThat(dtos).isNotNull();
+        assertThat(dtos).hasSize(2);
+
+        CommunityBoardGetResponseDto board1 = dtos.getLast();
+        assertThat(board1.id()).isEqualTo(communityId1);
+        assertThat(board1.writerNickname()).isEqualTo(savedVolunteer.getNickname());
+        assertThat(board1.title()).isEqualTo(dto1.title());
+        assertThat(board1.createdAt()).isEqualTo(communityBoard1.get().getCreatedAt());
+
+        CommunityBoardGetResponseDto board2 = dtos.getFirst();
+        assertThat(board2.id()).isEqualTo(communityId2);
+        assertThat(board2.writerNickname()).isEqualTo(savedVolunteer.getNickname());
+        assertThat(board2.title()).isEqualTo(dto2.title());
+        assertThat(board2.createdAt()).isEqualTo(communityBoard2.get().getCreatedAt());
+    }
+
+    @DisplayName("커뮤니티 게시글의 상세 정보를 조회한다.")
+    @Test
+    void getCommunityBoardDetail() {
+
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+        Volunteer savedVolunteer = volunteerRepository.save(volunteer);
+
+        CommunityBoardCreateRequestDto dto1 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목")
+                .content("커뮤니티 테스트 내용")
+                .build();
+
+        String imgUrl = "https://image.test.url/123";
+
+        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
+
+        //when
+        CommunityBoardGetDetailResponseDto communityBoard = communityBoardQueryService.getCommunityBoardDetail(communityId1);
+
+        //then
+        assertThat(communityBoard).isNotNull();
+        assertThat(communityBoard.id()).isEqualTo(communityId1);
+        assertThat(communityBoard.title()).isEqualTo("커뮤니티 테스트 제목");
+        assertThat(communityBoard.content()).isEqualTo("커뮤니티 테스트 내용");
+        assertThat(communityBoard.imageUrl()).isEqualTo("https://image.test.url/123");
+
+        assertThat(communityBoard.writerDetailDto().id()).isEqualTo(savedVolunteer.getId());
+        assertThat(communityBoard.writerDetailDto().name()).isEqualTo(savedVolunteer.getNickname());
+        assertThat(communityBoard.writerDetailDto().imgUrl()).isEqualTo(savedVolunteer.getImgUrl());
+        assertThat(communityBoard.writerDetailDto().tier()).isEqualTo(savedVolunteer.getTier());
+    }
+
+    @DisplayName("삭제된 커뮤니티 게시글의 상세 정보를 조회할 때 예외를 던진다.")
+    @Test
+    void getCommunityBoardDetailWithDeletedId() {
+
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+        Volunteer savedVolunteer = volunteerRepository.save(volunteer);
+
+        CommunityBoardCreateRequestDto dto1 = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목")
+                .content("커뮤니티 테스트 내용")
+                .build();
+
+        String imgUrl = "https://image.test.url/123";
+
+        Long communityId = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
+
+        communityBoardRepository.deleteAllInBatch();
+
+        //when
+        ThrowableAssert.ThrowingCallable callable = () -> communityBoardQueryService.getCommunityBoardDetail(communityId);
+
+        //then
+        assertThatExceptionOfType(BadRequestException.class)
+                .isThrownBy(callable)
+                .withMessage(ExceptionMessage.NOT_EXISTS_COMMUNITY_BOARD.getMessage());
+
+    }
+}
+

--- a/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
@@ -88,8 +88,10 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
         Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
 
-        assertThat(dtos).isNotNull();
-        assertThat(dtos).hasSize(2);
+
+        assertThat(dtos)
+                .isNotNull()
+                .hasSize(2);
 
         CommunityBoardGetResponseDto board1 = dtos.getLast();
         assertThat(board1.id()).isEqualTo(communityId1);
@@ -114,17 +116,6 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
 
         Volunteer savedVolunteer = volunteerRepository.save(volunteer);
 
-        Center center = Center.create(
-                "기본 기관 이름",
-                "010-1234-5678",
-                "http://example.com/image.jpg",
-                "기관 소개 내용",
-                "http://example.com",
-                "account123",
-                "password123"
-        );
-        Center savedCenter = centerRepository.save(center);
-
         CommunityBoardCreateRequestDto dto1 = CommunityBoardCreateRequestDto.builder()
                 .title("커뮤니티 테스트 제목1")
                 .content("커뮤니티 테스트 내용1")
@@ -135,16 +126,10 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
                 .content("커뮤니티 테스트 내용2")
                 .build();
 
-        CommunityBoardCreateRequestDto dto3 = CommunityBoardCreateRequestDto.builder()
-                .title("커뮤니티 테스트 제목3")
-                .content("커뮤니티 테스트 내용23")
-                .build();
-
         String imgUrl1 = "https://image.test.url/123";
 
         Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), null);
         Long communityId2 = createCommunityBoardService.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
-        Long communityId3 = createCommunityBoardService.createCommunityBoard(dto3, savedCenter.getId(), imgUrl1);
 
         //when
         List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoardsByWriterId(volunteer.getId());
@@ -153,8 +138,9 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
         Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
 
-        assertThat(dtos).isNotNull();
-        assertThat(dtos).hasSize(2);
+        assertThat(dtos)
+                .isNotNull()
+                .hasSize(2);
 
         CommunityBoardGetResponseDto board1 = dtos.getLast();
         assertThat(board1.id()).isEqualTo(communityId1);

--- a/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
@@ -9,7 +9,7 @@ import com.somemore.community.dto.request.CommunityBoardCreateRequestDto;
 import com.somemore.community.dto.response.CommunityBoardGetDetailResponseDto;
 import com.somemore.community.dto.response.CommunityBoardGetResponseDto;
 import com.somemore.community.repository.CommunityBoardRepository;
-import com.somemore.community.service.command.CreateCommunityBoardService;
+import com.somemore.community.usecase.command.CreateCommunityBoardUseCase;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.global.exception.ExceptionMessage;
 import com.somemore.volunteer.domain.Volunteer;
@@ -35,7 +35,7 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
     @Autowired
     CenterRepository centerRepository;
     @Autowired
-    CreateCommunityBoardService createCommunityBoardService;
+    CreateCommunityBoardUseCase createCommunityBoardUseCase;
     @Autowired
     CommunityBoardQueryService communityBoardQueryService;
 
@@ -52,7 +52,7 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         String oAuthId = "example-oauth-id";
         Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
 
-       Volunteer savedVolunteer = volunteerRepository.save(volunteer);
+        Volunteer savedVolunteer = volunteerRepository.save(volunteer);
 
         Center center = Center.create(
                 "기본 기관 이름",
@@ -78,8 +78,8 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
 
         String imgUrl1 = "https://image.test.url/123";
 
-        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedCenter.getId(), null);
-        Long communityId2 = createCommunityBoardService.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
+        Long communityId1 = createCommunityBoardUseCase.createCommunityBoard(dto1, savedCenter.getId(), null);
+        Long communityId2 = createCommunityBoardUseCase.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
 
         // when
         List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoards();
@@ -128,8 +128,8 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
 
         String imgUrl1 = "https://image.test.url/123";
 
-        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), null);
-        Long communityId2 = createCommunityBoardService.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
+        Long communityId1 = createCommunityBoardUseCase.createCommunityBoard(dto1, savedVolunteer.getId(), null);
+        Long communityId2 = createCommunityBoardUseCase.createCommunityBoard(dto2, savedVolunteer.getId(), imgUrl1);
 
         //when
         List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoardsByWriterId(volunteer.getId());
@@ -172,7 +172,7 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
 
         String imgUrl = "https://image.test.url/123";
 
-        Long communityId1 = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
+        Long communityId1 = createCommunityBoardUseCase.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
 
         //when
         CommunityBoardGetDetailResponseDto communityBoard = communityBoardQueryService.getCommunityBoardDetail(communityId1);
@@ -207,7 +207,7 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
 
         String imgUrl = "https://image.test.url/123";
 
-        Long communityId = createCommunityBoardService.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
+        Long communityId = createCommunityBoardUseCase.createCommunityBoard(dto1, savedVolunteer.getId(), imgUrl);
 
         communityBoardRepository.deleteAllInBatch();
 

--- a/src/test/java/com/somemore/volunteer/repository/VolunteerRepositoryTest.java
+++ b/src/test/java/com/somemore/volunteer/repository/VolunteerRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.somemore.volunteer.repository;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.auth.oauth.OAuthProvider;
+import com.somemore.center.domain.Center;
+import com.somemore.volunteer.domain.Volunteer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Transactional
+public class VolunteerRepositoryTest extends IntegrationTestSupport {
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+
+    @DisplayName("봉사자의 id로 닉네임을 조회한다. (Repository)")
+    @Test
+    void findNicknameById() {
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+        volunteerRepository.save(volunteer);
+
+        //when
+        String volunteerNickname = volunteerRepository.findNicknameById(volunteer.getId());
+
+        //then
+        assertThat(volunteerNickname).isEqualTo(volunteer.getNickname());
+    }
+}

--- a/src/test/java/com/somemore/volunteer/repository/VolunteerRepositoryTest.java
+++ b/src/test/java/com/somemore/volunteer/repository/VolunteerRepositoryTest.java
@@ -2,17 +2,16 @@ package com.somemore.volunteer.repository;
 
 import com.somemore.IntegrationTestSupport;
 import com.somemore.auth.oauth.OAuthProvider;
-import com.somemore.center.domain.Center;
 import com.somemore.volunteer.domain.Volunteer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
-public class VolunteerRepositoryTest extends IntegrationTestSupport {
+class VolunteerRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private VolunteerRepository volunteerRepository;
 

--- a/src/test/java/com/somemore/volunteer/service/query/FindVolunteerIdServiceTest.java
+++ b/src/test/java/com/somemore/volunteer/service/query/FindVolunteerIdServiceTest.java
@@ -57,4 +57,21 @@ class FindVolunteerIdServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> findVolunteerIdService.findVolunteerIdByOAuthId(oAuthId))
                 .isInstanceOf(EntityNotFoundException.class);
     }
+
+    @DisplayName("봉사자의 id로 nickname을 조회한다.")
+    @Test
+    void getNicknameById() {
+
+        //given
+        String oAuthId = "example-oauth-id";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+
+        volunteerRepository.save(volunteer);
+
+        //when
+        String nickname = findVolunteerIdService.getNicknameById(volunteer.getId());
+
+        //then
+        assertThat(nickname).isEqualTo(volunteer.getNickname());
+    }
 }


### PR DESCRIPTION
resolved : 
- #19 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
커뮤니티 게시글 조회 기능

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 커뮤니티 게시글 전체 리스트 조회 기능
- 커뮤니티 게시글 리스트 작성자별 조회 기능
- 커뮤니티 게시글 상세 조회 기능
- center name 조회 기능
- center 커뮤니티 게시글에 포함될 상세 정보 조회 기능
- volunteer nickname 조회 기능
- volunteer 커뮤니티 게시글에 포함될 상세 정보 조회 기능

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
작성자 정보 조회 과정에서 center와 volunteer responseDto를 WriterDetailDto interface를 implements 받는 구조로 구현하였는데 WriterDetailDto 이름이나 디렉토리 위치가 어떤지 리뷰 남겨주시면 감사하겠습니다!
