### PR TITLE
[BUILD FAIL] Refactor/51 커뮤니티 게시글 id로 조회 로직 QueryDSL로 변경

### DIFF
--- a/src/main/java/com/somemore/community/repository/CommunityBoardRepository.java
+++ b/src/main/java/com/somemore/community/repository/CommunityBoardRepository.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface CommunityBoardRepository {
     CommunityBoard save(CommunityBoard communityBoard);
-    Optional<CommunityBoard> findById(Long id);
+    Optional<CommunityBoard> getCommunityBoardWithId(Long id);
     List<CommunityBoard> getCommunityBoards();
     List<CommunityBoard> getCommunityBoardsByWriterId(UUID writerId);
     void deleteAllInBatch();

--- a/src/main/java/com/somemore/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/com/somemore/community/repository/CommunityRepositoryImpl.java
@@ -23,8 +23,14 @@ public class CommunityRepositoryImpl implements CommunityBoardRepository {
     }
 
     @Override
-    public Optional<CommunityBoard> findById(Long id) {
-        return communityBoardJpaRepository.findById(id);
+    public Optional<CommunityBoard> getCommunityBoardWithId(Long id) {
+        QCommunityBoard communityBoard = QCommunityBoard.communityBoard;
+
+        return Optional.ofNullable(queryFactory
+                .selectFrom(communityBoard)
+                .where(communityBoard.id.eq(id)
+                        .and(communityBoard.deleted.eq(false)))
+                .fetchOne());
     }
 
     @Override

--- a/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
+++ b/src/main/java/com/somemore/community/service/query/CommunityBoardQueryService.java
@@ -53,7 +53,7 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
 
     @Override
     public CommunityBoardGetDetailResponseDto getCommunityBoardDetail(Long id) {
-        CommunityBoard board = communityBoardRepository.findById(id)
+        CommunityBoard board = communityBoardRepository.getCommunityBoardWithId(id)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTS_COMMUNITY_BOARD.getMessage()));
 
         return CommunityBoardGetDetailResponseDto.fromEntity(board, getWriterDetail(board.getWriterId()));

--- a/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityRepositoryTest.java
@@ -19,9 +19,9 @@ class CommunityRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private CommunityBoardRepository communityBoardRepository;
 
-    @DisplayName("커뮤니티 id로 커뮤니티 상세 정보를 조회할 수 있다. (Repository)")
+    @DisplayName("커뮤니티 게시글 id로 커뮤니티 상세 정보를 조회할 수 있다. (Repository)")
     @Test
-    void findById() {
+    void getCommunityBoardById() {
         //given
         CommunityBoard communityBoard = CommunityBoard.builder()
                 .title("테스트 커뮤니티 게시글 제목")
@@ -33,7 +33,7 @@ class CommunityRepositoryTest extends IntegrationTestSupport {
         communityBoardRepository.save(communityBoard);
 
         //when
-        Optional<CommunityBoard> foundCommunityBoard = communityBoardRepository.findById(communityBoard.getId());
+        Optional<CommunityBoard> foundCommunityBoard = communityBoardRepository.getCommunityBoardWithId(communityBoard.getId());
 
         //then
         assertThat(foundCommunityBoard).isNotNull();
@@ -41,6 +41,27 @@ class CommunityRepositoryTest extends IntegrationTestSupport {
         assertThat(foundCommunityBoard.get().getContent()).isEqualTo("테스트 커뮤니티 게시글 내용");
         assertThat(foundCommunityBoard.get().getImgUrl()).isEqualTo("http://community.example.com/123");
         assertThat(foundCommunityBoard.get().getWriterId()).isEqualTo(communityBoard.getWriterId());
+    }
+
+    @DisplayName("삭제된 커뮤니티 id로 커뮤니티 상세 정보를 조회할 때 예외를 반환할 수 있다. (Repository)")
+    @Test
+    void getCommunityBoardByDeletedId() {
+        //given
+        CommunityBoard communityBoard = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목")
+                .content("테스트 커뮤니티 게시글 내용")
+                .imgUrl("http://community.example.com/123")
+                .writerId(UUID.randomUUID())
+                .build();
+
+        communityBoardRepository.save(communityBoard);
+        communityBoardRepository.deleteAllInBatch();
+
+        //when
+        Optional<CommunityBoard> foundCommunityBoard = communityBoardRepository.getCommunityBoardWithId(communityBoard.getId());
+
+        //then
+        assertThat(foundCommunityBoard).isEmpty();
     }
 
     @DisplayName("저장된 전체 커뮤니티 게시글을 목록으로 조회할 수 있다. (Repository)")

--- a/src/test/java/com/somemore/community/service/command/CreateCommunityBoardServiceTest.java
+++ b/src/test/java/com/somemore/community/service/command/CreateCommunityBoardServiceTest.java
@@ -41,7 +41,7 @@ class CreateCommunityBoardServiceTest extends IntegrationTestSupport {
         Long communityId = createCommunityBoardService.createCommunityBoard(dto, writerId, imgUrl);
 
         //then
-        Optional<CommunityBoard> communityBoard = communityBoardRepository.findById(communityId);
+        Optional<CommunityBoard> communityBoard = communityBoardRepository.getCommunityBoardWithId(communityId);
 
         assertThat(communityBoard).isPresent();
         assertThat(communityBoard.get().getId()).isEqualTo(communityId);
@@ -67,7 +67,7 @@ class CreateCommunityBoardServiceTest extends IntegrationTestSupport {
         Long communityId = createCommunityBoardService.createCommunityBoard(dto, writerId, imgUrl);
 
         //then
-        Optional<CommunityBoard> communityBoard = communityBoardRepository.findById(communityId);
+        Optional<CommunityBoard> communityBoard = communityBoardRepository.getCommunityBoardWithId(communityId);
 
         assertThat(communityBoard).isPresent();
         assertThat(communityBoard.get().getId()).isEqualTo(communityId);

--- a/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/community/service/query/CommunityBoardQueryServiceTest.java
@@ -85,8 +85,8 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoards();
 
         // then
-        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
-        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
+        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.getCommunityBoardWithId(communityId1);
+        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.getCommunityBoardWithId(communityId2);
 
 
         assertThat(dtos)
@@ -135,8 +135,8 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         List<CommunityBoardGetResponseDto> dtos = communityBoardQueryService.getCommunityBoardsByWriterId(volunteer.getId());
 
         //then
-        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.findById(communityId1);
-        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.findById(communityId2);
+        Optional<CommunityBoard> communityBoard1 = communityBoardRepository.getCommunityBoardWithId(communityId1);
+        Optional<CommunityBoard> communityBoard2 = communityBoardRepository.getCommunityBoardWithId(communityId2);
 
         assertThat(dtos)
                 .isNotNull()


### PR DESCRIPTION
resolved : 
- #51 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
findById 조회 기능 JPA -> QueryDSL

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
삭제된 게시글의 경우에도 조회가 되어 QueryDSL로 deleted 조건 추가하였습니다.
