### PR TITLE
[BUILD FAIL] Bug/80 커뮤니티 댓글 필드 수정

### DIFF
--- a/src/main/java/com/somemore/community/domain/CommunityComment.java
+++ b/src/main/java/com/somemore/community/domain/CommunityComment.java
@@ -22,6 +22,9 @@ public class CommunityComment extends BaseEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
+    @Column(name = "community_board_id", nullable = false)
+    private Long communityBoardId;
+
     @Column(name = "writer_id", nullable = false, length = 16)
     private UUID writerId;
 
@@ -33,7 +36,8 @@ public class CommunityComment extends BaseEntity {
     private Long parentCommentId;
 
     @Builder
-    public CommunityComment(UUID writerId, String content, Long parentCommentId) {
+    public CommunityComment(Long communityBoardId, UUID writerId, String content, Long parentCommentId) {
+        this.communityBoardId = communityBoardId;
         this.writerId = writerId;
         this.content = content;
         this.parentCommentId = parentCommentId;

--- a/src/main/java/com/somemore/community/dto/request/CommunityCommentCreateRequestDto.java
+++ b/src/main/java/com/somemore/community/dto/request/CommunityCommentCreateRequestDto.java
@@ -6,6 +6,7 @@ import com.somemore.community.domain.CommunityComment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.UUID;
@@ -13,15 +14,19 @@ import java.util.UUID;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Builder
 public record CommunityCommentCreateRequestDto(
+        @Schema(description = "커뮤니티 게시글 ID", example = "33")
+        @NotNull(message = "게시글 ID는 필수 값입니다.")
+        Long communityBoardId,
         @Schema(description = "커뮤니티 댓글 내용", example = "저도 함께 하고 싶습니다.")
         @NotBlank(message = "댓글 내용은 필수 값입니다.")
         String content,
-        @Schema(description = "부모 댓글의 ID", example = "1234", nullable = true)
+        @Schema(description = "부모 댓글 ID", example = "1234", nullable = true)
         @Nullable
         Long parentCommentId
 ) {
     public CommunityComment toEntity(UUID writerId) {
         return CommunityComment.builder()
+                .communityBoardId(communityBoardId)
                 .writerId(writerId)
                 .content(content)
                 .parentCommentId(parentCommentId)

--- a/src/main/java/com/somemore/community/repository/board/CommunityBoardRepository.java
+++ b/src/main/java/com/somemore/community/repository/board/CommunityBoardRepository.java
@@ -12,5 +12,9 @@ public interface CommunityBoardRepository {
     Optional<CommunityBoard> findById(Long id);
     List<CommunityBoardView> getCommunityBoards();
     List<CommunityBoardView> findByWriterId(UUID writerId);
+    boolean existsById(Long id);
+    default boolean doesNotExistById(Long id) {
+        return !existsById(id);
+    }
     void deleteAllInBatch();
 }

--- a/src/main/java/com/somemore/community/repository/board/CommunityBoardRepositoryImpl.java
+++ b/src/main/java/com/somemore/community/repository/board/CommunityBoardRepositoryImpl.java
@@ -52,6 +52,18 @@ public class CommunityBoardRepositoryImpl implements CommunityBoardRepository {
                 .fetch();
     }
 
+    @Override
+    public boolean existsById(Long id) {
+        QCommunityBoard communityBoard = QCommunityBoard.communityBoard;
+
+        return queryFactory
+                .selectOne()
+                .from(communityBoard)
+                .where(communityBoard.id.eq(id)
+                        .and(communityBoard.deleted.eq(false)))
+                .fetchFirst() != null;
+    }
+
     private JPAQuery<CommunityBoardView> getCommunityBoardsQuery() {
         QCommunityBoard communityBoard = QCommunityBoard.communityBoard;
         QVolunteer volunteer = QVolunteer.volunteer;

--- a/src/main/java/com/somemore/community/service/comment/CreateCommunityCommentService.java
+++ b/src/main/java/com/somemore/community/service/comment/CreateCommunityCommentService.java
@@ -2,6 +2,7 @@ package com.somemore.community.service.comment;
 
 import com.somemore.community.domain.CommunityComment;
 import com.somemore.community.dto.request.CommunityCommentCreateRequestDto;
+import com.somemore.community.repository.board.CommunityBoardRepository;
 import com.somemore.community.repository.comment.CommunityCommentRepository;
 import com.somemore.community.usecase.comment.CreateCommunityCommentUseCase;
 import com.somemore.global.exception.BadRequestException;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNITY_BOARD;
 import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNITY_COMMENT;
 
 @RequiredArgsConstructor
@@ -18,15 +20,24 @@ import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNIT
 @Service
 public class CreateCommunityCommentService implements CreateCommunityCommentUseCase {
 
+    private final CommunityBoardRepository communityBoardRepository;
     private final CommunityCommentRepository communityCommentRepository;
 
     @Override
     public Long createCommunityComment(CommunityCommentCreateRequestDto requestDto, UUID writerId) {
         CommunityComment communityComment = requestDto.toEntity(writerId);
 
+        validateCommunityBoardExists(communityComment.getCommunityBoardId());
+
         validateParentCommentExists(communityComment.getParentCommentId());
 
         return communityCommentRepository.save(communityComment).getId();
+    }
+
+    private void validateCommunityBoardExists(Long communityBoardId) {
+        if (communityBoardRepository.doesNotExistById(communityBoardId)) {
+            throw new BadRequestException(NOT_EXISTS_COMMUNITY_BOARD.getMessage());
+        }
     }
 
     private void validateParentCommentExists(Long parentCommentId) {

--- a/src/test/java/com/somemore/community/repository/CommunityBoardRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityBoardRepositoryTest.java
@@ -158,4 +158,27 @@ class CommunityBoardRepositoryTest extends IntegrationTestSupport {
         assertThat(communityBoards.getLast().writerNickname()).isEqualTo(volunteer.getNickname());
         assertThat(communityBoards.getLast().communityBoard().getCreatedAt()).isEqualTo(communityBoard1.getCreatedAt());
     }
+
+    @DisplayName("게시글 id로 게시글이 존재하는지 확인할 수 있다.")
+    @Test
+    void existsById() {
+
+        //given
+        UUID writerId = UUID.randomUUID();
+
+        CommunityBoard communityBoard = CommunityBoard.builder()
+                .title("테스트 커뮤니티 게시글 제목")
+                .content("테스트 커뮤니티 게시글 내용")
+                .imgUrl("http://community.example.com/123")
+                .writerId(writerId)
+                .build();
+
+        CommunityBoard savedComment = communityBoardRepository.save(communityBoard);
+
+        //when
+        boolean isExist = communityBoardRepository.existsById(savedComment.getId());
+
+        //then
+        assertThat(isExist).isTrue();
+    }
 }

--- a/src/test/java/com/somemore/community/service/comment/DeleteCommunityCommentServiceTest.java
+++ b/src/test/java/com/somemore/community/service/comment/DeleteCommunityCommentServiceTest.java
@@ -1,8 +1,10 @@
 package com.somemore.community.service.comment;
 
 import com.somemore.IntegrationTestSupport;
+import com.somemore.community.dto.request.CommunityBoardCreateRequestDto;
 import com.somemore.community.dto.request.CommunityCommentCreateRequestDto;
 import com.somemore.community.repository.comment.CommunityCommentRepository;
+import com.somemore.community.usecase.board.CreateCommunityBoardUseCase;
 import com.somemore.community.usecase.comment.CreateCommunityCommentUseCase;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.global.exception.ExceptionMessage;
@@ -26,13 +28,25 @@ class DeleteCommunityCommentServiceTest extends IntegrationTestSupport {
     private CreateCommunityCommentUseCase createCommunityCommentUseCase;
     @Autowired
     private CommunityCommentRepository communityCommentRepository;
+    @Autowired
+    private CreateCommunityBoardUseCase createCommunityBoardUseCase;
 
     private UUID writerId;
     private Long commentId;
 
     @BeforeEach
     void setUp() {
+        CommunityBoardCreateRequestDto boardDto = CommunityBoardCreateRequestDto.builder()
+                .title("커뮤니티 테스트 제목")
+                .content("커뮤니티 테스트 내용")
+                .build();
+
+        writerId = UUID.randomUUID();
+
+        Long boardId = createCommunityBoardUseCase.createCommunityBoard(boardDto, writerId, null);
+
         CommunityCommentCreateRequestDto dto = CommunityCommentCreateRequestDto.builder()
+                .communityBoardId(boardId)
                 .content("커뮤니티 댓글 테스트 내용")
                 .parentCommentId(null)
                 .build();


### PR DESCRIPTION
resolved : 
- #80 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
커뮤니티 댓글 누락된 communityBoardId 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 엔티티 및 DTO에 필드 추가
- 게시글 repository에 existsById 추가 및 검증 테스트 추가
- 댓글 생성 serivce에 게시글 검증 로직 추가
- 댓글 생성, 삭제 테스트 수정

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 뭔가 이상하다 했는데 조회 구현하다가 빠진 걸 알았네요... 죄송합니다.. 이거 머지하면 댓글 수정 쪽은 반영해서 pr 다시 올리겠습니다.