### PR TITLE
[BUILD FAIL] Feature/97 봉사자 프로필 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // Data Layer: JPA, Redis, Database Drivers
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/somemore/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/somemore/global/handler/GlobalExceptionHandler.java
@@ -5,12 +5,12 @@ import com.somemore.global.exception.DuplicateException;
 import com.somemore.global.exception.ImageUploadException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
-public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+public class GlobalExceptionHandler {
 
     //예시 코드
     @ExceptionHandler(BadRequestException.class)
@@ -41,6 +41,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("중복 예외");
+
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ProblemDetail handleMethodArgumentNotValid(final MethodArgumentNotValidException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+
+        problemDetail.setTitle("유효성 예외");
+        problemDetail.setDetail("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
 
         return problemDetail;
     }

--- a/src/main/java/com/somemore/volunteer/controller/VolunteerProfileCommandController.java
+++ b/src/main/java/com/somemore/volunteer/controller/VolunteerProfileCommandController.java
@@ -1,0 +1,53 @@
+package com.somemore.volunteer.controller;
+
+import com.somemore.global.common.response.ApiResponse;
+import com.somemore.imageupload.dto.ImageUploadRequestDto;
+import com.somemore.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+import com.somemore.volunteer.usecase.UpdateVolunteerProfileUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/profile")
+@Tag(name = "PUT Volunteer", description = "봉사자 프로필 수정")
+public class VolunteerProfileCommandController {
+
+    private final UpdateVolunteerProfileUseCase updateVolunteerProfileUseCase;
+    private final ImageUploadUseCase imageUploadUseCase;
+
+    @Secured("ROLE_VOLUNTEER")
+    @Operation(summary = "프로필 수정", description = "현재 로그인된 사용자의 프로필을 수정합니다.")
+    @PutMapping(consumes = MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> updateProfile(
+            @AuthenticationPrincipal String volunteerId,
+            @Valid @RequestPart("data") VolunteerProfileUpdateRequestDto requestDto,
+            @RequestPart(value = "img_file", required = false) MultipartFile image) {
+
+        String imgUrl = imageUploadUseCase.uploadImage(new ImageUploadRequestDto(image));
+
+        updateVolunteerProfileUseCase.update(
+                UUID.fromString(volunteerId),
+                requestDto,
+                imgUrl
+        );
+
+        return ApiResponse.ok("프로필 수정 성공");
+    }
+}

--- a/src/main/java/com/somemore/volunteer/controller/VolunteerProfileQueryController.java
+++ b/src/main/java/com/somemore/volunteer/controller/VolunteerProfileQueryController.java
@@ -1,7 +1,7 @@
 package com.somemore.volunteer.controller;
 
 import com.somemore.global.common.response.ApiResponse;
-import com.somemore.volunteer.dto.response.VolunteerResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.usecase.VolunteerQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,14 +21,14 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
 @Tag(name = "GET Volunteer", description = "봉사자 조회")
-public class VolunteerQueryController {
+public class VolunteerProfileQueryController {
 
     private final VolunteerQueryUseCase volunteerQueryUseCase;
 
     @Operation(summary = "본인 상세 프로필 조회", description = "현재 로그인된 사용자의 상세 프로필을 조회합니다.")
     @Secured("ROLE_VOLUNTEER")
     @GetMapping("/me")
-    public ApiResponse<VolunteerResponseDto> getMyProfile(
+    public ApiResponse<VolunteerProfileResponseDto> getMyProfile(
             @AuthenticationPrincipal String volunteerId) {
 
         return ApiResponse.ok(
@@ -39,7 +39,7 @@ public class VolunteerQueryController {
 
     @GetMapping("/{volunteerId}")
     @Operation(summary = "타인 프로필 조회", description = "특정 봉사자의 프로필을 조회합니다. 상세 정보는 포함되지 않습니다.")
-    public ApiResponse<VolunteerResponseDto> getVolunteerProfile(
+    public ApiResponse<VolunteerProfileResponseDto> getVolunteerProfile(
             @PathVariable UUID volunteerId) {
 
         return ApiResponse.ok(
@@ -52,7 +52,7 @@ public class VolunteerQueryController {
     @GetMapping("/{volunteerId}/detailed")
     @Secured("ROLE_CENTER")
     @Operation(summary = "지원자 상세 프로필 조회", description = "기관이 작성한 모집 글에 지원한 봉사자의 상세 프로필을 조회합니다.")
-    public ApiResponse<VolunteerResponseDto> getVolunteerDetailedProfile(
+    public ApiResponse<VolunteerProfileResponseDto> getVolunteerDetailedProfile(
             @PathVariable UUID volunteerId,
             @AuthenticationPrincipal String centerId) {
 

--- a/src/main/java/com/somemore/volunteer/domain/Volunteer.java
+++ b/src/main/java/com/somemore/volunteer/domain/Volunteer.java
@@ -2,6 +2,7 @@ package com.somemore.volunteer.domain;
 
 import com.somemore.auth.oauth.OAuthProvider;
 import com.somemore.global.common.BaseEntity;
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -56,6 +57,12 @@ public class Volunteer extends BaseEntity {
                 .totalVolunteerHours(0)
                 .totalVolunteerCount(0)
                 .build();
+    }
+
+    public void updateWith(VolunteerProfileUpdateRequestDto dto, String imgUrl) {
+        this.nickname = dto.nickname();
+        this.introduce = dto.introduce();
+        this.imgUrl = imgUrl;
     }
 
     @Builder

--- a/src/main/java/com/somemore/volunteer/dto/request/VolunteerProfileUpdateRequestDto.java
+++ b/src/main/java/com/somemore/volunteer/dto/request/VolunteerProfileUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.somemore.volunteer.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record VolunteerProfileUpdateRequestDto(
+
+        @Schema(description = "봉사자 닉네임", example = "making")
+        @NotBlank(message = "닉네임은 필수 값입니다.")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 입력 가능합니다.")
+        String nickname,
+
+        @Schema(description = "봉사자 소개글", example = "저는 다양한 봉사활동에 관심이 많은 봉사자입니다.")
+        @NotBlank(message = "소개글은 필수 값입니다.")
+        @Size(max = 100, message = "소개글은 최대 100자까지 입력 가능합니다.")
+        String introduce
+) {
+}

--- a/src/main/java/com/somemore/volunteer/dto/response/VolunteerProfileResponseDto.java
+++ b/src/main/java/com/somemore/volunteer/dto/response/VolunteerProfileResponseDto.java
@@ -30,8 +30,8 @@ public record VolunteerProfileResponseDto(
         @Schema(description = "총 봉사 횟수", example = "20")
         Integer totalVolunteerCount,
 
-        @Schema(description = "봉사자 상세 정보", implementation = VolunteerDetailProfileResponseDto.class)
-        VolunteerDetailProfileResponseDto volunteerDetailProfileResponseDto
+        @Schema(description = "봉사자 상세 정보", implementation = Detail.class)
+        Detail detail
 ) {
 
     public static VolunteerProfileResponseDto from(
@@ -46,7 +46,7 @@ public record VolunteerProfileResponseDto(
                 volunteer.getTier().name(),
                 volunteer.getTotalVolunteerHours(),
                 volunteer.getTotalVolunteerCount(),
-                VolunteerDetailProfileResponseDto.from(volunteerDetail)
+                Detail.from(volunteerDetail)
         );
     }
 
@@ -66,8 +66,8 @@ public record VolunteerProfileResponseDto(
     }
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    @Schema(description = "봉사자 상세 프로필 응답 DTO")
-    private record VolunteerDetailProfileResponseDto(
+    @Schema(description = "봉사자 상세 프로필")
+    private record Detail(
             @Schema(description = "이름", example = "홍길동")
             String name,
 
@@ -83,10 +83,10 @@ public record VolunteerProfileResponseDto(
             @Schema(description = "연락처", example = "010-1234-5678")
             String contactNumber
     ) {
-        public static VolunteerDetailProfileResponseDto from(
+        public static Detail from(
                 VolunteerDetail volunteerDetail
         ) {
-            return new VolunteerDetailProfileResponseDto(
+            return new Detail(
                     volunteerDetail.getName(),
                     volunteerDetail.getEmail(),
                     volunteerDetail.getGender().name(),

--- a/src/main/java/com/somemore/volunteer/dto/response/VolunteerProfileResponseDto.java
+++ b/src/main/java/com/somemore/volunteer/dto/response/VolunteerProfileResponseDto.java
@@ -7,8 +7,8 @@ import com.somemore.volunteer.domain.VolunteerDetail;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Schema(description = "봉사자 응답 DTO")
-public record VolunteerResponseDto(
+@Schema(description = "봉사자 프로필 응답 DTO")
+public record VolunteerProfileResponseDto(
         @Schema(description = "봉사자 ID", example = "123e4567-e89b-12d3-a456-426614174000")
         String volunteerId,
 
@@ -30,15 +30,15 @@ public record VolunteerResponseDto(
         @Schema(description = "총 봉사 횟수", example = "20")
         Integer totalVolunteerCount,
 
-        @Schema(description = "봉사자 상세 정보", implementation = VolunteerDetailResponseDto.class)
-        VolunteerDetailResponseDto volunteerDetailResponseDto
+        @Schema(description = "봉사자 상세 정보", implementation = VolunteerDetailProfileResponseDto.class)
+        VolunteerDetailProfileResponseDto volunteerDetailProfileResponseDto
 ) {
 
-    public static VolunteerResponseDto from(
+    public static VolunteerProfileResponseDto from(
             Volunteer volunteer,
             VolunteerDetail volunteerDetail
     ) {
-        return new VolunteerResponseDto(
+        return new VolunteerProfileResponseDto(
                 volunteer.getId().toString(),
                 volunteer.getNickname(),
                 volunteer.getImgUrl(),
@@ -46,14 +46,14 @@ public record VolunteerResponseDto(
                 volunteer.getTier().name(),
                 volunteer.getTotalVolunteerHours(),
                 volunteer.getTotalVolunteerCount(),
-                VolunteerDetailResponseDto.from(volunteerDetail)
+                VolunteerDetailProfileResponseDto.from(volunteerDetail)
         );
     }
 
-    public static VolunteerResponseDto from(
+    public static VolunteerProfileResponseDto from(
             Volunteer volunteer
     ) {
-        return new VolunteerResponseDto(
+        return new VolunteerProfileResponseDto(
                 volunteer.getId().toString(),
                 volunteer.getNickname(),
                 volunteer.getImgUrl(),
@@ -66,8 +66,8 @@ public record VolunteerResponseDto(
     }
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    @Schema(description = "봉사자 상세 응답 DTO")
-    private record VolunteerDetailResponseDto(
+    @Schema(description = "봉사자 상세 프로필 응답 DTO")
+    private record VolunteerDetailProfileResponseDto(
             @Schema(description = "이름", example = "홍길동")
             String name,
 
@@ -83,10 +83,10 @@ public record VolunteerResponseDto(
             @Schema(description = "연락처", example = "010-1234-5678")
             String contactNumber
     ) {
-        public static VolunteerDetailResponseDto from(
+        public static VolunteerDetailProfileResponseDto from(
                 VolunteerDetail volunteerDetail
         ) {
-            return new VolunteerDetailResponseDto(
+            return new VolunteerDetailProfileResponseDto(
                     volunteerDetail.getName(),
                     volunteerDetail.getEmail(),
                     volunteerDetail.getGender().name(),

--- a/src/main/java/com/somemore/volunteer/service/UpdateVolunteerProfileService.java
+++ b/src/main/java/com/somemore/volunteer/service/UpdateVolunteerProfileService.java
@@ -1,0 +1,33 @@
+package com.somemore.volunteer.service;
+
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import com.somemore.volunteer.usecase.UpdateVolunteerProfileUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateVolunteerProfileService implements UpdateVolunteerProfileUseCase {
+
+    private final VolunteerRepository volunteerRepository;
+
+    @Override
+    public void update(UUID volunteerId, VolunteerProfileUpdateRequestDto requestDto, String imgUrl) {
+        Volunteer volunteer = volunteerRepository.findById(volunteerId)
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTS_VOLUNTEER));
+
+        volunteer.updateWith(requestDto, imgUrl);
+    }
+
+}

--- a/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
+++ b/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
@@ -4,7 +4,7 @@ import com.somemore.facade.validator.VolunteerDetailAccessValidator;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.domain.VolunteerDetail;
-import com.somemore.volunteer.dto.response.VolunteerResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
 import com.somemore.volunteer.usecase.VolunteerQueryUseCase;
@@ -28,27 +28,27 @@ public class VolunteerQueryService implements VolunteerQueryUseCase {
     private final VolunteerDetailAccessValidator volunteerDetailAccessValidator;
 
     @Override
-    public VolunteerResponseDto getMyProfile(UUID volunteerId) {
+    public VolunteerProfileResponseDto getMyProfile(UUID volunteerId) {
 
-        return VolunteerResponseDto.from(
+        return VolunteerProfileResponseDto.from(
                 findVolunteer(volunteerId),
                 findVolunteerDetail(volunteerId)
         );
     }
 
     @Override
-    public VolunteerResponseDto getVolunteerProfile(UUID volunteerId) {
+    public VolunteerProfileResponseDto getVolunteerProfile(UUID volunteerId) {
 
-        return VolunteerResponseDto.from(
+        return VolunteerProfileResponseDto.from(
                 findVolunteer(volunteerId)
         );
     }
 
     @Override
-    public VolunteerResponseDto getVolunteerDetailedProfile(UUID volunteerId, UUID centerId) {
+    public VolunteerProfileResponseDto getVolunteerDetailedProfile(UUID volunteerId, UUID centerId) {
         volunteerDetailAccessValidator.validateByCenterId(centerId, volunteerId);
 
-        return VolunteerResponseDto.from(
+        return VolunteerProfileResponseDto.from(
                 findVolunteer(volunteerId),
                 findVolunteerDetail(volunteerId)
         );

--- a/src/main/java/com/somemore/volunteer/usecase/UpdateVolunteerProfileUseCase.java
+++ b/src/main/java/com/somemore/volunteer/usecase/UpdateVolunteerProfileUseCase.java
@@ -1,0 +1,10 @@
+package com.somemore.volunteer.usecase;
+
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+
+import java.util.UUID;
+
+public interface UpdateVolunteerProfileUseCase {
+
+    void update(UUID volunteerId, VolunteerProfileUpdateRequestDto requestDto, String imgUrl);
+}

--- a/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
+++ b/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
@@ -1,16 +1,16 @@
 package com.somemore.volunteer.usecase;
 
-import com.somemore.volunteer.dto.response.VolunteerResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 
 import java.util.UUID;
 
 public interface VolunteerQueryUseCase {
 
-    VolunteerResponseDto getMyProfile(UUID volunteerId);
+    VolunteerProfileResponseDto getMyProfile(UUID volunteerId);
 
-    VolunteerResponseDto getVolunteerProfile(UUID volunteerId);
+    VolunteerProfileResponseDto getVolunteerProfile(UUID volunteerId);
 
-    VolunteerResponseDto getVolunteerDetailedProfile(UUID volunteerId, UUID centerId);
+    VolunteerProfileResponseDto getVolunteerDetailedProfile(UUID volunteerId, UUID centerId);
 
     UUID getVolunteerIdByOAuthId(String oAuthId);
 

--- a/src/test/java/com/somemore/volunteer/controller/VolunteerProfileCommandControllerTest.java
+++ b/src/test/java/com/somemore/volunteer/controller/VolunteerProfileCommandControllerTest.java
@@ -1,0 +1,182 @@
+package com.somemore.volunteer.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.somemore.ControllerTestSupport;
+import com.somemore.WithMockCustomUser;
+import com.somemore.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+import com.somemore.volunteer.usecase.UpdateVolunteerProfileUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UpdateVolunteerProfileUseCase updateVolunteerProfileUseCase;
+
+    @MockBean
+    private ImageUploadUseCase imageUploadUseCase;
+
+    @DisplayName("봉사자 프로필 수정 성공 테스트")
+    @Test
+    @WithMockCustomUser(role = "VOLUNTEER")
+    void updateVolunteerProfile() throws Exception {
+        // given
+        VolunteerProfileUpdateRequestDto requestDto = VolunteerProfileUpdateRequestDto.builder()
+                .nickname("making")
+                .introduce("making is making")
+                .build();
+
+        MockMultipartFile imageFile = createMockImageFile();
+        MockMultipartFile requestData = createMockRequestData(requestDto);
+
+        String mockImageUrl = "http://example.com/image/profile-image.jpg";
+
+        given(imageUploadUseCase.uploadImage(any())).willReturn(mockImageUrl);
+        willDoNothing().given(updateVolunteerProfileUseCase)
+                .update(any(UUID.class), any(VolunteerProfileUpdateRequestDto.class), anyString());
+
+        MockMultipartHttpServletRequestBuilder builder = createMockRequestBuilder();
+
+        // when
+        mockMvc.perform(builder
+                        .file(requestData)
+                        .file(imageFile)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                // then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.message").value("프로필 수정 성공"));
+    }
+
+    @DisplayName("봉사자 프로필 수정의 닉네임 유효성 검사 실패 테스트")
+    @Test
+    @WithMockCustomUser(role = "VOLUNTEER")
+    void testNicknameValidation() throws Exception {
+        // given
+        VolunteerProfileUpdateRequestDto invalidRequestDto = VolunteerProfileUpdateRequestDto.builder()
+                .nickname("TooLongNickname") // 10자를 초과
+                .introduce("Valid introduction")
+                .build();
+
+        MockMultipartFile imageFile = createMockImageFile();
+        MockMultipartFile requestData = createMockRequestData(invalidRequestDto);
+
+        MockMultipartHttpServletRequestBuilder builder = createMockRequestBuilder();
+
+        // when
+        mockMvc.perform(builder
+                        .file(requestData)
+                        .file(imageFile)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    String responseBody = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+                    Map<String, Object> jsonResponse = objectMapper.readValue(responseBody, new TypeReference<>() {
+                    });
+                    String detail = (String) jsonResponse.get("detail");
+
+                    assertThat(detail).isEqualTo("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
+                });
+    }
+
+    @DisplayName("봉사자 프로필 수정의 소개 유효성 검사 실패 테스트")
+    @Test
+    @WithMockCustomUser(role = "VOLUNTEER")
+    void testIntroduceValidation() throws Exception {
+        // given
+        VolunteerProfileUpdateRequestDto invalidRequestDto = VolunteerProfileUpdateRequestDto.builder()
+                .nickname("making")
+                .introduce("""
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_
+                        """)
+                .build();
+
+        MockMultipartFile imageFile = createMockImageFile();
+        MockMultipartFile requestData = createMockRequestData(invalidRequestDto);
+
+        MockMultipartHttpServletRequestBuilder builder = createMockRequestBuilder();
+
+        // when
+        mockMvc.perform(builder
+                        .file(requestData)
+                        .file(imageFile)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                .andExpect(status().isBadRequest())
+                .andDo(result -> {
+                    String responseBody = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+                    Map<String, Object> jsonResponse = objectMapper.readValue(responseBody, new TypeReference<>() {
+                    });
+                    String detail = (String) jsonResponse.get("detail");
+
+                    assertThat(detail).isEqualTo("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
+                });
+    }
+
+    private MockMultipartFile createMockImageFile() {
+        return new MockMultipartFile(
+                "img_file",
+                "profile-image.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "profile image content".getBytes()
+        );
+    }
+
+    private MockMultipartFile createMockRequestData(Object dto) throws Exception {
+        return new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(dto)
+        );
+    }
+
+    private MockMultipartHttpServletRequestBuilder createMockRequestBuilder() {
+        MockMultipartHttpServletRequestBuilder builder = multipart("/api/profile");
+        builder.with(request -> {
+            request.setMethod("PUT");
+            return request;
+        });
+        return builder;
+    }
+}

--- a/src/test/java/com/somemore/volunteer/service/UpdateVolunteerProfileServiceTest.java
+++ b/src/test/java/com/somemore/volunteer/service/UpdateVolunteerProfileServiceTest.java
@@ -1,0 +1,64 @@
+package com.somemore.volunteer.service;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.auth.oauth.OAuthProvider;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+class UpdateVolunteerProfileServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UpdateVolunteerProfileService updateVolunteerProfileService;
+
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+
+    final String oAuthId = "example-oauth-id";
+    final OAuthProvider oAuthProvider = OAuthProvider.NAVER;
+    final String imgUrl = "http://example.com/updated-image.jpg";
+    final VolunteerProfileUpdateRequestDto requestDto = new VolunteerProfileUpdateRequestDto(
+            "Updated Nickname",
+            "Updated Introduction"
+    );
+
+
+    @Test
+    @DisplayName("봉사자 프로필을 성공적으로 업데이트한다")
+    void updateVolunteerProfileSuccess() {
+        // given
+        Volunteer volunteer = Volunteer.createDefault(oAuthProvider, oAuthId);
+        volunteerRepository.save(volunteer);
+
+        // when
+        updateVolunteerProfileService.update(volunteer.getId(), requestDto, imgUrl);
+
+        // then
+        Volunteer updatedVolunteer = volunteerRepository.findById(volunteer.getId()).orElseThrow();
+        assertThat(updatedVolunteer.getNickname()).isEqualTo(requestDto.nickname());
+        assertThat(updatedVolunteer.getIntroduce()).isEqualTo(requestDto.introduce());
+        assertThat(updatedVolunteer.getImgUrl()).isEqualTo(imgUrl);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 봉사자 ID로 업데이트 시 예외를 던진다")
+    void updateVolunteerProfileThrowsWhenNotFound() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> updateVolunteerProfileService.update(UUID.randomUUID(), requestDto, imgUrl))
+                .isInstanceOf(com.somemore.global.exception.BadRequestException.class)
+                .hasMessage(NOT_EXISTS_VOLUNTEER.getMessage());
+    }
+}

--- a/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
+++ b/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
@@ -6,7 +6,7 @@ import com.somemore.global.exception.BadRequestException;
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.domain.VolunteerDetail;
 import com.somemore.volunteer.dto.request.VolunteerRegisterRequestDto;
-import com.somemore.volunteer.dto.response.VolunteerResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -103,7 +103,7 @@ class VolunteerQueryServiceTest extends IntegrationTestSupport {
         volunteerDetailRepository.save(volunteerDetail);
 
         // when
-        VolunteerResponseDto response = volunteerQueryService.getMyProfile(volunteerId);
+        VolunteerProfileResponseDto response = volunteerQueryService.getMyProfile(volunteerId);
 
         // then
         assertThat(response).isNotNull();
@@ -123,13 +123,13 @@ class VolunteerQueryServiceTest extends IntegrationTestSupport {
         volunteerDetailRepository.save(volunteerDetail);
 
         // when
-        VolunteerResponseDto response = volunteerQueryService.getVolunteerProfile(volunteerId);
+        VolunteerProfileResponseDto response = volunteerQueryService.getVolunteerProfile(volunteerId);
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.volunteerId()).isEqualTo(volunteerId.toString());
         assertThat(response.nickname()).isEqualTo(volunteer.getNickname());
-        assertThat(response.volunteerDetailResponseDto()).isNull();
+        assertThat(response.volunteerDetailProfileResponseDto()).isNull();
     }
 
     @DisplayName("권한이 없는 기관의 봉사자 상세 프로필 조회 실패")


### PR DESCRIPTION
**resolved**:  
- #97 

---

## 📌 **과제 설명**
- 봉사자 프로필 수정 기능을 추가하였습니다.
- 사용자는 닉네임, 소개글, 프로필 이미지를 수정할 수 있습니다.
- RequestDto에 대한 유효성 검사가 추가되었고, 관련 테스트도 구현하였습니다.

---

## 👩‍💻 **요구 사항과 구현 내용**

1. **봉사자 업데이트 (domain, usecase-service, controller)**

2. `build(gradle): validation 의존성 추가`
   - 유효성 검사를 위해 `spring-boot-starter-validation`을 추가하였습니다.

3. `feat(GlobalExceptionHandler): 유효성 예외를 전역 예외 핸들러로 처리`
   - `MethodArgumentNotValidException` 발생 시 사용자에게 명확한 오류 메시지를 제공하도록 `GlobalExceptionHandler`를 수정하였습니다. 일관성을 위해서 기존의 상속 구조를 포기했습니다.

4. Volunteer 패키지 내의 명확하지 않은 클래스들 Rename.

---

## ✅ **PR 포인트 & 궁금한 점**
1. 닉네임 10자, 소개 100자가 적절하지 않다면 알려주세요!