### PR TITLE
Feature/138 봉사 지원 조회 기능

### DIFF
--- a/src/main/java/com/somemore/recruitboard/dto/response/RecruitBoardOverViewResponseDto.java
+++ b/src/main/java/com/somemore/recruitboard/dto/response/RecruitBoardOverViewResponseDto.java
@@ -1,0 +1,24 @@
+package com.somemore.recruitboard.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@JsonNaming(SnakeCaseStrategy.class)
+@Builder
+public record RecruitBoardOverViewResponseDto(
+        @Schema(description = "모집글 아이디", example = "1")
+        Long id,
+        @Schema(description = "모집글 제목", example = "서울시 도서관 봉사 활동 모집")
+        String title
+) {
+
+    public static RecruitBoardOverViewResponseDto from(RecruitBoard recruitBoard) {
+        return RecruitBoardOverViewResponseDto.builder()
+                .id(recruitBoard.getId())
+                .title(recruitBoard.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
@@ -1,17 +1,14 @@
 package com.somemore.recruitboard.repository;
 
 import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardNearByCondition;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardDetail;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithLocation;
-import com.somemore.recruitboard.dto.condition.RecruitBoardNearByCondition;
-import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
-
 import java.util.List;
-
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.data.domain.Page;
 
 public interface RecruitBoardRepository {
@@ -31,4 +28,6 @@ public interface RecruitBoardRepository {
     Page<RecruitBoard> findAllByCenterId(UUID centerId, RecruitBoardSearchCondition condition);
 
     List<Long> findNotCompletedIdsByCenterId(UUID centerId);
+
+    List<RecruitBoard> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImpl.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImpl.java
@@ -14,20 +14,16 @@ import com.somemore.location.domain.QLocation;
 import com.somemore.location.utils.GeoUtils;
 import com.somemore.recruitboard.domain.QRecruitBoard;
 import com.somemore.recruitboard.domain.RecruitBoard;
-
-import java.util.List;
-
 import com.somemore.recruitboard.domain.RecruitStatus;
 import com.somemore.recruitboard.domain.VolunteerCategory;
+import com.somemore.recruitboard.dto.condition.RecruitBoardNearByCondition;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardDetail;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithLocation;
-import com.somemore.recruitboard.dto.condition.RecruitBoardNearByCondition;
-import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
-
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
@@ -77,6 +73,17 @@ public class RecruitBoardRepositoryImpl implements RecruitBoardRepository {
                                 .and(isNotCompleted())
                                 .and(isNotDeleted())
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<RecruitBoard> findAllByIds(List<Long> ids) {
+        BooleanExpression exp = recruitBoard.id.in(ids)
+                .and(isNotCompleted());
+
+        return queryFactory
+                .selectFrom(recruitBoard)
+                .where(exp)
                 .fetch();
     }
 
@@ -160,7 +167,7 @@ public class RecruitBoardRepositoryImpl implements RecruitBoardRepository {
 
     @Override
     public Page<RecruitBoard> findAllByCenterId(UUID centerId,
-                                                RecruitBoardSearchCondition condition) {
+            RecruitBoardSearchCondition condition) {
         QRecruitBoard recruitBoard = QRecruitBoard.recruitBoard;
 
         Pageable pageable = condition.pageable();

--- a/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardQueryService.java
+++ b/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardQueryService.java
@@ -1,5 +1,7 @@
 package com.somemore.recruitboard.service.query;
 
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_RECRUIT_BOARD;
+
 import com.somemore.center.usecase.query.CenterQueryUseCase;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.recruitboard.domain.RecruitBoard;
@@ -14,15 +16,12 @@ import com.somemore.recruitboard.repository.mapper.RecruitBoardDetail;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithLocation;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_RECRUIT_BOARD;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -70,7 +69,7 @@ public class RecruitBoardQueryService implements RecruitBoardQueryUseCase {
 
     @Override
     public Page<RecruitBoardResponseDto> getRecruitBoardsByCenterId(UUID centerId,
-                                                                    RecruitBoardSearchCondition condition) {
+            RecruitBoardSearchCondition condition) {
         centerQueryUseCase.validateCenterExists(centerId);
 
         Page<RecruitBoard> boards = recruitBoardRepository.findAllByCenterId(centerId, condition);
@@ -80,6 +79,11 @@ public class RecruitBoardQueryService implements RecruitBoardQueryUseCase {
     @Override
     public List<Long> getNotCompletedIdsByCenterIds(UUID centerId) {
         return recruitBoardRepository.findNotCompletedIdsByCenterId(centerId);
+    }
+
+    @Override
+    public List<RecruitBoard> getAllByIds(List<Long> ids) {
+        return recruitBoardRepository.findAllByIds(ids);
     }
 
 }

--- a/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardQueryUseCase.java
+++ b/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardQueryUseCase.java
@@ -29,4 +29,5 @@ public interface RecruitBoardQueryUseCase {
 
     List<Long> getNotCompletedIdsByCenterIds(UUID centerId);
 
+    List<RecruitBoard> getAllByIds(List<Long> ids);
 }

--- a/src/main/java/com/somemore/volunteer/dto/response/VolunteerSimpleInfoResponseDto.java
+++ b/src/main/java/com/somemore/volunteer/dto/response/VolunteerSimpleInfoResponseDto.java
@@ -1,0 +1,35 @@
+package com.somemore.volunteer.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+import lombok.Builder;
+
+@Schema(description = "봉사자 간단 정보 응답 DTO")
+@JsonNaming(SnakeCaseStrategy.class)
+@Builder
+public record VolunteerSimpleInfoResponseDto(
+        @Schema(description = "봉사자 ID", example = "f5a8779a-bcc9-4fc5-b8a1-7b2a383054a9")
+        UUID id,
+        @Schema(description = "봉사자 이름", example = "홍길동")
+        String name,
+        @Schema(description = "봉사자 닉네임", example = "gil-dong")
+        String nickname,
+        @Schema(description = "봉사자 이메일", example = "hong@example.com")
+        String email,
+        @Schema(description = "봉사자 이미지 URL", example = "https://example.com/images/hong.jpg")
+        String imgUrl
+) {
+
+    public static VolunteerSimpleInfoResponseDto from(VolunteerSimpleInfo volunteerSimpleInfo) {
+        return VolunteerSimpleInfoResponseDto.builder()
+                .id(volunteerSimpleInfo.id())
+                .name(volunteerSimpleInfo.name())
+                .nickname(volunteerSimpleInfo.nickname())
+                .email(volunteerSimpleInfo.email())
+                .imgUrl(volunteerSimpleInfo.imgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/volunteer/repository/VolunteerRepository.java
+++ b/src/main/java/com/somemore/volunteer/repository/VolunteerRepository.java
@@ -2,11 +2,11 @@ package com.somemore.volunteer.repository;
 
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.repository.mapper.VolunteerOverviewForRankingByHours;
-import org.springframework.stereotype.Repository;
-
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VolunteerRepository {
@@ -24,4 +24,6 @@ public interface VolunteerRepository {
     void deleteAllInBatch();
 
     List<Volunteer> findAllByIds(List<UUID> volunteerIds);
+
+    List<VolunteerSimpleInfo> findSimpleInfoByIds(List<UUID> ids);
 }

--- a/src/main/java/com/somemore/volunteer/repository/VolunteerRepositoryImpl.java
+++ b/src/main/java/com/somemore/volunteer/repository/VolunteerRepositoryImpl.java
@@ -5,14 +5,15 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.somemore.volunteer.domain.QVolunteer;
+import com.somemore.volunteer.domain.QVolunteerDetail;
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.repository.mapper.VolunteerOverviewForRankingByHours;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
@@ -22,6 +23,7 @@ public class VolunteerRepositoryImpl implements VolunteerRepository {
     private final JPAQueryFactory queryFactory;
 
     private static final QVolunteer volunteer = QVolunteer.volunteer;
+    private static final QVolunteerDetail volunteerDetail = QVolunteerDetail.volunteerDetail;
 
     @Override
     public Volunteer save(Volunteer volunteer) {
@@ -70,6 +72,25 @@ public class VolunteerRepositoryImpl implements VolunteerRepository {
     @Override
     public List<Volunteer> findAllByIds(List<UUID> volunteerIds) {
         return volunteerJpaRepository.findAllByIdInAndDeletedFalse(volunteerIds);
+    }
+
+    @Override
+    public List<VolunteerSimpleInfo> findSimpleInfoByIds(List<UUID> ids) {
+        BooleanExpression exp = volunteer.id.in(ids)
+                .and(isNotDeleted());
+
+        return queryFactory
+                .select(Projections.constructor(VolunteerSimpleInfo.class,
+                        volunteer.id,
+                        volunteerDetail.name,
+                        volunteer.nickname,
+                        volunteerDetail.email,
+                        volunteer.imgUrl,
+                        volunteer.tier))
+                .from(volunteer)
+                .join(volunteerDetail).on(volunteer.id.eq(volunteerDetail.volunteerId))
+                .where(exp)
+                .fetch();
     }
 
     private Optional<Volunteer> findOne(BooleanExpression condition) {

--- a/src/main/java/com/somemore/volunteer/repository/mapper/VolunteerSimpleInfo.java
+++ b/src/main/java/com/somemore/volunteer/repository/mapper/VolunteerSimpleInfo.java
@@ -1,0 +1,15 @@
+package com.somemore.volunteer.repository.mapper;
+
+import com.somemore.volunteer.domain.Tier;
+import java.util.UUID;
+
+public record VolunteerSimpleInfo(
+        UUID id,
+        String name,
+        String nickname,
+        String email,
+        String imgUrl,
+        Tier tier
+) {
+
+}

--- a/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
+++ b/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
@@ -1,24 +1,25 @@
 package com.somemore.volunteer.service;
 
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
+
 import com.somemore.facade.validator.VolunteerDetailAccessValidator;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.domain.VolunteerDetail;
 import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
 import com.somemore.volunteer.repository.mapper.VolunteerOverviewForRankingByHours;
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import com.somemore.volunteer.usecase.VolunteerQueryUseCase;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
 
 @Slf4j
 @Service
@@ -49,7 +50,7 @@ public class VolunteerQueryService implements VolunteerQueryUseCase {
 
     @Override
     public VolunteerProfileResponseDto getVolunteerDetailedProfile(UUID volunteerId,
-                                                                   UUID centerId) {
+            UUID centerId) {
         volunteerDetailAccessValidator.validateByCenterId(centerId, volunteerId);
 
         return VolunteerProfileResponseDto.from(
@@ -85,6 +86,18 @@ public class VolunteerQueryService implements VolunteerQueryUseCase {
     @Override
     public List<Volunteer> getAllByIds(List<UUID> volunteerIds) {
         return volunteerRepository.findAllByIds(volunteerIds);
+    }
+
+    @Override
+    public List<VolunteerSimpleInfoResponseDto> getVolunteerSimpleInfosByIds(
+            List<UUID> volunteerIds) {
+
+        List<VolunteerSimpleInfo> volunteerSimpleInfos = volunteerRepository.findSimpleInfoByIds(
+                volunteerIds);
+
+        return volunteerSimpleInfos.stream()
+                .map(VolunteerSimpleInfoResponseDto::from)
+                .toList();
     }
 
     private Volunteer findVolunteer(UUID volunteerId) {

--- a/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
+++ b/src/main/java/com/somemore/volunteer/service/VolunteerQueryService.java
@@ -8,7 +8,6 @@ import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.domain.VolunteerDetail;
 import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
-import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
 import com.somemore.volunteer.repository.mapper.VolunteerOverviewForRankingByHours;
@@ -89,15 +88,8 @@ public class VolunteerQueryService implements VolunteerQueryUseCase {
     }
 
     @Override
-    public List<VolunteerSimpleInfoResponseDto> getVolunteerSimpleInfosByIds(
-            List<UUID> volunteerIds) {
-
-        List<VolunteerSimpleInfo> volunteerSimpleInfos = volunteerRepository.findSimpleInfoByIds(
-                volunteerIds);
-
-        return volunteerSimpleInfos.stream()
-                .map(VolunteerSimpleInfoResponseDto::from)
-                .toList();
+    public List<VolunteerSimpleInfo> getVolunteerSimpleInfosByIds(List<UUID> ids) {
+        return volunteerRepository.findSimpleInfoByIds(ids);
     }
 
     private Volunteer findVolunteer(UUID volunteerId) {

--- a/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
+++ b/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
@@ -4,6 +4,7 @@ import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,5 +24,5 @@ public interface VolunteerQueryUseCase {
 
     List<Volunteer> getAllByIds(List<UUID> volunteerIds);
 
-    List<VolunteerSimpleInfoResponseDto> getVolunteerSimpleInfosByIds(List<UUID> volunteerIds);
+    List<VolunteerSimpleInfo> getVolunteerSimpleInfosByIds(List<UUID> ids);
 }

--- a/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
+++ b/src/main/java/com/somemore/volunteer/usecase/VolunteerQueryUseCase.java
@@ -3,7 +3,7 @@ package com.somemore.volunteer.usecase;
 import com.somemore.volunteer.domain.Volunteer;
 import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
-
+import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,4 +22,6 @@ public interface VolunteerQueryUseCase {
     VolunteerRankingResponseDto getRankingByHours();
 
     List<Volunteer> getAllByIds(List<UUID> volunteerIds);
+
+    List<VolunteerSimpleInfoResponseDto> getVolunteerSimpleInfosByIds(List<UUID> volunteerIds);
 }

--- a/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyCommandApiController.java
+++ b/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyCommandApiController.java
@@ -2,7 +2,7 @@ package com.somemore.volunteerapply.controller;
 
 import com.somemore.auth.annotation.CurrentUser;
 import com.somemore.global.common.response.ApiResponse;
-import com.somemore.volunteerapply.dto.VolunteerApplyCreateRequestDto;
+import com.somemore.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
 import com.somemore.volunteerapply.usecase.ApplyVolunteerApplyUseCase;
 import com.somemore.volunteerapply.usecase.WithdrawVolunteerApplyUseCase;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
+++ b/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
@@ -6,9 +6,10 @@ import com.somemore.auth.annotation.CurrentUser;
 import com.somemore.global.common.response.ApiResponse;
 import com.somemore.volunteerapply.domain.ApplyStatus;
 import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
-import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyRecruitInfoResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyVolunteerInfoResponseDto;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,10 +61,32 @@ public class VolunteerApplyQueryApiController {
         );
     }
 
+    @Operation(summary = "특정 봉사자 봉사 지원 리스트 조회", description = "특정 봉사자의 봉사 지원 리스트를 조회합니다.")
+    @GetMapping("/volunteer-applies/volunteer/{volunteerId}")
+    public ApiResponse<Page<VolunteerApplyRecruitInfoResponseDto>> getVolunteerAppliesByVolunteerId(
+            @PathVariable UUID volunteerId,
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
+            @RequestParam(required = false) Boolean attended,
+            @RequestParam(required = false) ApplyStatus status
+    ) {
+        VolunteerApplySearchCondition condition = VolunteerApplySearchCondition.builder()
+                .attended(attended)
+                .status(status)
+                .pageable(pageable)
+                .build();
+
+        return ApiResponse.ok(
+                200,
+                volunteerApplyQueryFacadeUseCase.getVolunteerAppliesByVolunteerId(volunteerId,
+                        condition),
+                "봉사 지원 리스트 조회 성공"
+        );
+    }
+
     @Secured("ROLE_CENTER")
     @Operation(summary = "지원자 리스트 조회", description = "특정 모집글에 대한 지원자 리스트를 조회합니다.")
     @GetMapping("/volunteer-applies/recruit-board/{recruitBoardId}")
-    public ApiResponse<Page<VolunteerApplyDetailResponseDto>> getVolunteerApplies(
+    public ApiResponse<Page<VolunteerApplyVolunteerInfoResponseDto>> getVolunteerApplies(
             @CurrentUser UUID centerId,
             @PathVariable Long recruitBoardId,
             @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,

--- a/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
+++ b/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
@@ -1,0 +1,31 @@
+package com.somemore.volunteerapply.controller;
+
+import com.somemore.global.common.response.ApiResponse;
+import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class VolunteerApplyQueryApiController {
+
+    private final VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
+
+    @Operation(summary = "지원자 통계 조회", description = "특정 모집글에 대한 지원자 통계를 조회합니다.")
+    @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}/summary")
+    public ApiResponse<VolunteerApplySummaryResponseDto> getSummaryByRecruitBoardId(
+            @PathVariable Long recruitBoardId
+    ) {
+        return ApiResponse.ok(
+                200,
+                volunteerApplyQueryUseCase.getSummaryByRecruitBoardId(recruitBoardId),
+                "지원자 통계 조회 성공"
+        );
+    }
+}

--- a/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
+++ b/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
@@ -1,16 +1,28 @@
 package com.somemore.volunteerapply.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+import com.somemore.auth.annotation.CurrentUser;
 import com.somemore.global.common.response.ApiResponse;
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Volunteer Apply Query API", description = "봉사 활동 지원 조회 API")
@@ -20,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class VolunteerApplyQueryApiController {
 
     private final VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
+    private final VolunteerApplyQueryFacadeUseCase volunteerApplyQueryFacadeUseCase;
 
     @Operation(summary = "특정 모집글 봉사자 지원 단건 조회", description = "특정 모집글에 대한 봉사자 지원을 조회합니다.")
     @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}")
@@ -44,6 +57,29 @@ public class VolunteerApplyQueryApiController {
                 200,
                 volunteerApplyQueryUseCase.getSummaryByRecruitId(recruitBoardId),
                 "지원자 통계 조회 성공"
+        );
+    }
+
+    @Secured("ROLE_CENTER")
+    @Operation(summary = "지원자 리스트 조회", description = "특정 모집글에 대한 지원자 리스트를 조회합니다.")
+    @GetMapping("/volunteer-applies/recruit-board/{recruitBoardId}")
+    public ApiResponse<Page<VolunteerApplyDetailResponseDto>> getVolunteerApplies(
+            @CurrentUser UUID centerId,
+            @PathVariable Long recruitBoardId,
+            @PageableDefault(sort = "created_at", direction = DESC) Pageable pageable,
+            @RequestParam(required = false) Boolean attended,
+            @RequestParam(required = false) ApplyStatus status
+    ) {
+        VolunteerApplySearchCondition condition = VolunteerApplySearchCondition.builder()
+                .attended(attended)
+                .status(status)
+                .pageable(pageable)
+                .build();
+        return ApiResponse.ok(
+                200,
+                volunteerApplyQueryFacadeUseCase.getVolunteerAppliesByRecruitIdAndCenterId(
+                        recruitBoardId, centerId, condition),
+                "지원자 리스트 조회 성공"
         );
     }
 }

--- a/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
+++ b/src/main/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiController.java
@@ -1,15 +1,19 @@
 package com.somemore.volunteerapply.controller;
 
 import com.somemore.global.common.response.ApiResponse;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Volunteer Apply Query API", description = "봉사 활동 지원 조회 API")
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
@@ -17,14 +21,28 @@ public class VolunteerApplyQueryApiController {
 
     private final VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
 
+    @Operation(summary = "특정 모집글 봉사자 지원 단건 조회", description = "특정 모집글에 대한 봉사자 지원을 조회합니다.")
+    @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}")
+    public ApiResponse<VolunteerApplyResponseDto> getVolunteerApplyByRecruitIdAndVolunteerId(
+            @PathVariable Long recruitBoardId,
+            @PathVariable UUID volunteerId
+    ) {
+        return ApiResponse.ok(
+                200,
+                volunteerApplyQueryUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(
+                        recruitBoardId, volunteerId),
+                "특정 모집글에 대한 봉사자 지원 단건 조회 성공"
+        );
+    }
+
     @Operation(summary = "지원자 통계 조회", description = "특정 모집글에 대한 지원자 통계를 조회합니다.")
     @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}/summary")
-    public ApiResponse<VolunteerApplySummaryResponseDto> getSummaryByRecruitBoardId(
+    public ApiResponse<VolunteerApplySummaryResponseDto> getSummaryByRecruitId(
             @PathVariable Long recruitBoardId
     ) {
         return ApiResponse.ok(
                 200,
-                volunteerApplyQueryUseCase.getSummaryByRecruitBoardId(recruitBoardId),
+                volunteerApplyQueryUseCase.getSummaryByRecruitId(recruitBoardId),
                 "지원자 통계 조회 성공"
         );
     }

--- a/src/main/java/com/somemore/volunteerapply/dto/condition/VolunteerApplySearchCondition.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/condition/VolunteerApplySearchCondition.java
@@ -1,0 +1,15 @@
+package com.somemore.volunteerapply.dto.condition;
+
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import lombok.Builder;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+public record VolunteerApplySearchCondition(
+        ApplyStatus status,
+        Boolean attended,
+        Pageable pageable
+
+) {
+
+}

--- a/src/main/java/com/somemore/volunteerapply/dto/request/VolunteerApplyCreateRequestDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/request/VolunteerApplyCreateRequestDto.java
@@ -1,4 +1,4 @@
-package com.somemore.volunteerapply.dto;
+package com.somemore.volunteerapply.dto.request;
 
 import static com.somemore.volunteerapply.domain.ApplyStatus.WAITING;
 

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyDetailResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyDetailResponseDto.java
@@ -1,0 +1,47 @@
+package com.somemore.volunteerapply.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Schema(description = "봉사 지원자 상세 정보 응답 DTO")
+@JsonNaming(SnakeCaseStrategy.class)
+@Builder
+public record VolunteerApplyDetailResponseDto(
+        @Schema(description = "봉사 지원 ID", example = "123")
+        Long id,
+        @Schema(description = "모집글 ID", example = "2")
+        Long recruitBoardId,
+        @Schema(description = "지원 상태", example = "WAITING", allowableValues = {"WAITING",
+                "APPROVED", "REJECTED"})
+        ApplyStatus status,
+        @Schema(description = "참석 여부", example = "true")
+        Boolean attend,
+        @Schema(description = "지원 생성일", example = "2024-11-01T12:00:00")
+        LocalDateTime createdAt,
+        @Schema(description = "지원 수정일", example = "2024-11-05T12:00:00")
+        LocalDateTime updatedAt,
+        @Schema(description = "봉사자 정보", implementation = VolunteerSimpleInfoResponseDto.class)
+        VolunteerSimpleInfoResponseDto volunteer
+) {
+
+    public static VolunteerApplyDetailResponseDto of(
+            VolunteerApply volunteerApply,
+            VolunteerSimpleInfoResponseDto volunteer
+    ) {
+        return VolunteerApplyDetailResponseDto.builder()
+                .id(volunteerApply.getId())
+                .recruitBoardId(volunteerApply.getRecruitBoardId())
+                .status(volunteerApply.getStatus())
+                .attend(volunteerApply.getAttended())
+                .createdAt(volunteerApply.getCreatedAt())
+                .updatedAt(volunteerApply.getUpdatedAt())
+                .volunteer(volunteer)
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyRecruitInfoResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyRecruitInfoResponseDto.java
@@ -1,0 +1,48 @@
+package com.somemore.volunteerapply.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.response.RecruitBoardOverViewResponseDto;
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@JsonNaming(SnakeCaseStrategy.class)
+@Builder
+public record VolunteerApplyRecruitInfoResponseDto(
+        @Schema(description = "봉사 지원 ID", example = "123")
+        Long id,
+        @Schema(description = "봉사자 UUID", example = "f5a8779a-bcc9-4fc5-b8a1-7b2a383054a9")
+        UUID volunteerId,
+        @Schema(description = "지원 상태", example = "WAITING", allowableValues = {"WAITING",
+                "APPROVED", "REJECTED"})
+        ApplyStatus status,
+        @Schema(description = "참석 여부", example = "true")
+        Boolean attend,
+        @Schema(description = "지원 생성일", example = "2024-11-01T12:00:00")
+        LocalDateTime createdAt,
+        @Schema(description = "지원 수정일", example = "2024-11-05T12:00:00")
+        LocalDateTime updatedAt,
+        @Schema(description = "지원한 모집글 정보", implementation = RecruitBoardOverViewResponseDto.class)
+        RecruitBoardOverViewResponseDto recruitBoard
+) {
+
+    public static VolunteerApplyRecruitInfoResponseDto of(VolunteerApply apply,
+            RecruitBoard board) {
+        RecruitBoardOverViewResponseDto recruitBoard = RecruitBoardOverViewResponseDto.from(board);
+        return VolunteerApplyRecruitInfoResponseDto.builder()
+                .id(apply.getId())
+                .volunteerId(apply.getVolunteerId())
+                .status(apply.getStatus())
+                .attend(apply.getAttended())
+                .createdAt(apply.getCreatedAt())
+                .updatedAt(apply.getUpdatedAt())
+                .recruitBoard(recruitBoard)
+                .build();
+    }
+
+}

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyResponseDto.java
@@ -1,0 +1,43 @@
+package com.somemore.volunteerapply.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Builder
+public record VolunteerApplyResponseDto(
+        @Schema(description = "봉사 지원 ID", example = "1")
+        Long id,
+        @Schema(description = "봉사자 UUID", example = "f5a8779a-bcc9-4fc5-b8a1-7b2a383054a9")
+        UUID volunteerId,
+        @Schema(description = "모집글 ID", example = "101")
+        Long recruitBoardId,
+        @Schema(description = "지원 상태", example = "WAITING", allowableValues = {"WAITING",
+                "APPROVED", "REJECTED"})
+        ApplyStatus status,
+        @Schema(description = "봉사 참여 여부", example = "false")
+        Boolean attended,
+        @Schema(description = "지원서 생성 일시", example = "2024-11-01T12:00:00")
+        LocalDateTime createdAt,
+        @Schema(description = "지원서 수정 일시", example = "2024-11-01T12:30:00")
+        LocalDateTime updatedAt
+) {
+
+    public static VolunteerApplyResponseDto from(VolunteerApply volunteerApply) {
+        return VolunteerApplyResponseDto.builder()
+                .id(volunteerApply.getId())
+                .volunteerId(volunteerApply.getVolunteerId())
+                .recruitBoardId(volunteerApply.getRecruitBoardId())
+                .status(volunteerApply.getStatus())
+                .attended(volunteerApply.getAttended())
+                .createdAt(volunteerApply.getCreatedAt())
+                .updatedAt(volunteerApply.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplySummaryResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplySummaryResponseDto.java
@@ -1,0 +1,46 @@
+package com.somemore.volunteerapply.dto.response;
+
+import static com.somemore.volunteerapply.domain.ApplyStatus.APPROVED;
+import static com.somemore.volunteerapply.domain.ApplyStatus.REJECTED;
+import static com.somemore.volunteerapply.domain.ApplyStatus.WAITING;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.somemore.volunteerapply.domain.ApplyStatus;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Builder
+public record VolunteerApplySummaryResponseDto(
+        @Schema(description = "대기 인원", example = "5")
+        Long waiting,
+        @Schema(description = "승인 인원", example = "10")
+        Long approve,
+        @Schema(description = "거절 인원", example = "2")
+        Long reject,
+        @Schema(description = "총 지원자 수", example = "17")
+        Long total
+) {
+
+    public static VolunteerApplySummaryResponseDto from(List<VolunteerApply> volunteerApplies) {
+        Map<ApplyStatus, Long> statusCountMap = volunteerApplies.stream()
+                .collect(Collectors.groupingBy(VolunteerApply::getStatus, Collectors.counting()));
+
+        long waitingCount = statusCountMap.getOrDefault(WAITING, 0L);
+        long approveCount = statusCountMap.getOrDefault(APPROVED, 0L);
+        long rejectCount = statusCountMap.getOrDefault(REJECTED, 0L);
+        long totalCount = waitingCount + approveCount + rejectCount;
+
+        return VolunteerApplySummaryResponseDto.builder()
+                .waiting(waitingCount)
+                .approve(approveCount)
+                .reject(rejectCount)
+                .total(totalCount)
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyVolunteerInfoResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyVolunteerInfoResponseDto.java
@@ -3,6 +3,7 @@ package com.somemore.volunteerapply.dto.response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import com.somemore.volunteerapply.domain.ApplyStatus;
 import com.somemore.volunteerapply.domain.VolunteerApply;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -32,8 +33,10 @@ public record VolunteerApplyVolunteerInfoResponseDto(
 
     public static VolunteerApplyVolunteerInfoResponseDto of(
             VolunteerApply volunteerApply,
-            VolunteerSimpleInfoResponseDto volunteer
+            VolunteerSimpleInfo volunteerSimpleInfo
     ) {
+        VolunteerSimpleInfoResponseDto volunteer = VolunteerSimpleInfoResponseDto.from(
+                volunteerSimpleInfo);
         return VolunteerApplyVolunteerInfoResponseDto.builder()
                 .id(volunteerApply.getId())
                 .recruitBoardId(volunteerApply.getRecruitBoardId())

--- a/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyVolunteerInfoResponseDto.java
+++ b/src/main/java/com/somemore/volunteerapply/dto/response/VolunteerApplyVolunteerInfoResponseDto.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 @Schema(description = "봉사 지원자 상세 정보 응답 DTO")
 @JsonNaming(SnakeCaseStrategy.class)
 @Builder
-public record VolunteerApplyDetailResponseDto(
+public record VolunteerApplyVolunteerInfoResponseDto(
         @Schema(description = "봉사 지원 ID", example = "123")
         Long id,
         @Schema(description = "모집글 ID", example = "2")
@@ -30,11 +30,11 @@ public record VolunteerApplyDetailResponseDto(
         VolunteerSimpleInfoResponseDto volunteer
 ) {
 
-    public static VolunteerApplyDetailResponseDto of(
+    public static VolunteerApplyVolunteerInfoResponseDto of(
             VolunteerApply volunteerApply,
             VolunteerSimpleInfoResponseDto volunteer
     ) {
-        return VolunteerApplyDetailResponseDto.builder()
+        return VolunteerApplyVolunteerInfoResponseDto.builder()
                 .id(volunteerApply.getId())
                 .recruitBoardId(volunteerApply.getRecruitBoardId())
                 .status(volunteerApply.getStatus())

--- a/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
+++ b/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
@@ -28,4 +28,7 @@ public interface VolunteerApplyRepository {
 
     Page<VolunteerApply> findAllByRecruitId(Long recruitId,
             VolunteerApplySearchCondition condition);
+
+    Page<VolunteerApply> findAllByVolunteerId(UUID volunteerId,
+            VolunteerApplySearchCondition condition);
 }

--- a/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
+++ b/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
@@ -1,6 +1,7 @@
 package com.somemore.volunteerapply.repository;
 
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,4 +26,6 @@ public interface VolunteerApplyRepository {
 
     List<VolunteerApply> findAllByRecruitId(Long recruitId);
 
+    Page<VolunteerApply> findAllByRecruitId(Long recruitId,
+            VolunteerApplySearchCondition condition);
 }

--- a/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
+++ b/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepository.java
@@ -23,4 +23,6 @@ public interface VolunteerApplyRepository {
 
     Page<VolunteerApply> findAllByRecruitId(Long recruitId, Pageable pageable);
 
+    List<VolunteerApply> findAllByRecruitId(Long recruitId);
+
 }

--- a/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImpl.java
+++ b/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImpl.java
@@ -56,8 +56,7 @@ public class VolunteerApplyRepositoryImpl implements VolunteerApplyRepository {
     @Override
     public Page<VolunteerApply> findAllByRecruitId(Long recruitId, Pageable pageable) {
 
-        BooleanExpression exp = volunteerApply.recruitBoardId
-                .eq(recruitId)
+        BooleanExpression exp = recruitIdEq(recruitId)
                 .and(isNotDeleted());
 
         List<VolunteerApply> content = queryFactory
@@ -76,9 +75,21 @@ public class VolunteerApplyRepositoryImpl implements VolunteerApplyRepository {
     }
 
     @Override
+    public List<VolunteerApply> findAllByRecruitId(Long recruitId) {
+        BooleanExpression exp = recruitIdEq(recruitId)
+                .and(isNotDeleted());
+
+        return queryFactory
+                .select(volunteerApply)
+                .from(volunteerApply)
+                .where(exp)
+                .fetch();
+    }
+
+    @Override
     public Optional<VolunteerApply> findByRecruitIdAndVolunteerId(Long recruitId,
             UUID volunteerId) {
-        BooleanExpression exp = volunteerApply.recruitBoardId.eq(recruitId)
+        BooleanExpression exp = recruitIdEq(recruitId)
                 .and(volunteerApply.volunteerId.eq(volunteerId));
         return findOne(exp);
     }
@@ -87,8 +98,8 @@ public class VolunteerApplyRepositoryImpl implements VolunteerApplyRepository {
     public boolean existsByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId) {
         return queryFactory
                 .selectFrom(volunteerApply)
-                .where(volunteerApply.recruitBoardId.eq(recruitId)
-                        .and(volunteerApply.volunteerId.eq(volunteerId))
+                .where(recruitIdEq(recruitId)
+                        .and(volunteerIdEq(volunteerId))
                         .and(isNotDeleted()))
                 .fetchFirst() != null;
     }
@@ -112,6 +123,14 @@ public class VolunteerApplyRepositoryImpl implements VolunteerApplyRepository {
                         )
                         .fetchOne()
         );
+    }
+
+    private static BooleanExpression recruitIdEq(Long recruitId) {
+        return volunteerApply.recruitBoardId.eq(recruitId);
+    }
+
+    private static BooleanExpression volunteerIdEq(UUID volunteerId) {
+        return volunteerApply.volunteerId.eq(volunteerId);
     }
 
     private BooleanExpression isNotDeleted() {

--- a/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImpl.java
+++ b/src/main/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImpl.java
@@ -115,6 +115,32 @@ public class VolunteerApplyRepositoryImpl implements VolunteerApplyRepository {
     }
 
     @Override
+    public Page<VolunteerApply> findAllByVolunteerId(UUID volunteerId,
+            VolunteerApplySearchCondition condition) {
+
+        BooleanExpression exp = volunteerIdEq(volunteerId)
+                .and(attendedEq(condition.attended()))
+                .and(statusEq(condition.status()))
+                .and(isNotDeleted());
+
+        Pageable pageable = condition.pageable();
+
+        List<VolunteerApply> content = queryFactory
+                .selectFrom(volunteerApply)
+                .where(exp)
+                .orderBy(toOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(
+                content,
+                pageable,
+                getCount(exp)
+        );
+    }
+
+    @Override
     public Optional<VolunteerApply> findByRecruitIdAndVolunteerId(Long recruitId,
             UUID volunteerId) {
         BooleanExpression exp = recruitIdEq(recruitId)

--- a/src/main/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyService.java
@@ -7,7 +7,7 @@ import com.somemore.global.exception.BadRequestException;
 import com.somemore.recruitboard.domain.RecruitBoard;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
 import com.somemore.volunteerapply.domain.VolunteerApply;
-import com.somemore.volunteerapply.dto.VolunteerApplyCreateRequestDto;
+import com.somemore.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.volunteerapply.usecase.ApplyVolunteerApplyUseCase;
 import java.util.UUID;

--- a/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeService.java
@@ -1,0 +1,75 @@
+package com.somemore.volunteerapply.service;
+
+import static com.somemore.global.exception.ExceptionMessage.UNAUTHORIZED_RECRUIT_BOARD;
+
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
+import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
+import com.somemore.volunteer.usecase.VolunteerQueryUseCase;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
+import com.somemore.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class VolunteerApplyQueryFacadeService implements VolunteerApplyQueryFacadeUseCase {
+
+    private final VolunteerApplyRepository volunteerApplyRepository;
+    private final RecruitBoardQueryUseCase recruitBoardQueryUseCase;
+    private final VolunteerQueryUseCase volunteerQueryUseCase;
+
+    @Override
+    public Page<VolunteerApplyDetailResponseDto> getVolunteerAppliesByRecruitIdAndCenterId(
+            Long recruitId, UUID centerId, VolunteerApplySearchCondition condition) {
+        validateAuthorization(recruitId, centerId);
+
+        Page<VolunteerApply> applies = volunteerApplyRepository.findAllByRecruitId(recruitId,
+                condition);
+
+        Map<UUID, VolunteerSimpleInfoResponseDto> volunteerMap = getVolunteerInfoMap(
+                applies);
+
+        return applies.map(apply -> {
+            VolunteerSimpleInfoResponseDto volunteerInfo = volunteerMap.getOrDefault(
+                    apply.getVolunteerId(), null);
+            return VolunteerApplyDetailResponseDto.of(apply, volunteerInfo);
+        });
+    }
+
+    private Map<UUID, VolunteerSimpleInfoResponseDto> getVolunteerInfoMap(
+            Page<VolunteerApply> applies) {
+
+        List<UUID> volunteerIds = applies.getContent().stream()
+                .map(VolunteerApply::getVolunteerId)
+                .collect(Collectors.toList());
+
+        List<VolunteerSimpleInfoResponseDto> volunteers = volunteerQueryUseCase.getVolunteerSimpleInfosByIds(
+                volunteerIds);
+
+        return volunteers.stream()
+                .collect(Collectors.toMap(VolunteerSimpleInfoResponseDto::id,
+                        volunteer -> volunteer));
+    }
+
+    private void validateAuthorization(Long recruitId, UUID centerId) {
+        RecruitBoard recruitBoard = recruitBoardQueryUseCase.getById(recruitId);
+        if (recruitBoard.isWriter(centerId)) {
+            return;
+        }
+
+        throw new BadRequestException(UNAUTHORIZED_RECRUIT_BOARD);
+    }
+
+}

--- a/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryService.java
@@ -4,6 +4,7 @@ import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEE
 
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import java.util.List;
@@ -29,6 +30,15 @@ public class VolunteerApplyQueryService implements VolunteerApplyQueryUseCase {
     @Override
     public VolunteerApply getByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId) {
         return getVolunteerApplyBy(recruitId, volunteerId);
+    }
+
+    @Override
+    public VolunteerApplySummaryResponseDto getSummaryByRecruitBoardId(Long recruitBoardId) {
+
+        List<VolunteerApply> applies = volunteerApplyRepository.findAllByRecruitId(
+                recruitBoardId);
+
+        return VolunteerApplySummaryResponseDto.from(applies);
     }
 
     private VolunteerApply getVolunteerApplyBy(Long recruitBoardId, UUID volunteerId) {

--- a/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/VolunteerApplyQueryService.java
@@ -4,6 +4,7 @@ import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEE
 
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
@@ -29,21 +30,26 @@ public class VolunteerApplyQueryService implements VolunteerApplyQueryUseCase {
 
     @Override
     public VolunteerApply getByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId) {
-        return getVolunteerApplyBy(recruitId, volunteerId);
+        return volunteerApplyRepository.findByRecruitIdAndVolunteerId(recruitId, volunteerId)
+                .orElseThrow(
+                        () -> new BadRequestException(NOT_EXISTS_VOLUNTEER_APPLY));
     }
 
     @Override
-    public VolunteerApplySummaryResponseDto getSummaryByRecruitBoardId(Long recruitBoardId) {
+    public VolunteerApplySummaryResponseDto getSummaryByRecruitId(Long recruitId) {
 
         List<VolunteerApply> applies = volunteerApplyRepository.findAllByRecruitId(
-                recruitBoardId);
+                recruitId);
 
         return VolunteerApplySummaryResponseDto.from(applies);
     }
 
-    private VolunteerApply getVolunteerApplyBy(Long recruitBoardId, UUID volunteerId) {
-        return volunteerApplyRepository.findByRecruitIdAndVolunteerId(recruitBoardId,
-                volunteerId).orElseThrow(
-                () -> new BadRequestException(NOT_EXISTS_VOLUNTEER_APPLY.getMessage()));
+    @Override
+    public VolunteerApplyResponseDto getVolunteerApplyByRecruitIdAndVolunteerId(Long recruitId,
+            UUID volunteerId) {
+        VolunteerApply apply = getByRecruitIdAndVolunteerId(recruitId, volunteerId);
+
+        return VolunteerApplyResponseDto.from(apply);
     }
+
 }

--- a/src/main/java/com/somemore/volunteerapply/usecase/ApplyVolunteerApplyUseCase.java
+++ b/src/main/java/com/somemore/volunteerapply/usecase/ApplyVolunteerApplyUseCase.java
@@ -1,6 +1,6 @@
 package com.somemore.volunteerapply.usecase;
 
-import com.somemore.volunteerapply.dto.VolunteerApplyCreateRequestDto;
+import com.somemore.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
 import java.util.UUID;
 
 public interface ApplyVolunteerApplyUseCase {

--- a/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryFacadeUseCase.java
+++ b/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryFacadeUseCase.java
@@ -1,13 +1,18 @@
 package com.somemore.volunteerapply.usecase;
 
 import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
-import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyRecruitInfoResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyVolunteerInfoResponseDto;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 
 public interface VolunteerApplyQueryFacadeUseCase {
 
-    Page<VolunteerApplyDetailResponseDto> getVolunteerAppliesByRecruitIdAndCenterId(Long recruitId,
+    Page<VolunteerApplyVolunteerInfoResponseDto> getVolunteerAppliesByRecruitIdAndCenterId(
+            Long recruitId,
             UUID centerId, VolunteerApplySearchCondition condition);
+
+    Page<VolunteerApplyRecruitInfoResponseDto> getVolunteerAppliesByVolunteerId(UUID volunteerId,
+            VolunteerApplySearchCondition condition);
 
 }

--- a/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryFacadeUseCase.java
+++ b/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryFacadeUseCase.java
@@ -1,0 +1,13 @@
+package com.somemore.volunteerapply.usecase;
+
+import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+
+public interface VolunteerApplyQueryFacadeUseCase {
+
+    Page<VolunteerApplyDetailResponseDto> getVolunteerAppliesByRecruitIdAndCenterId(Long recruitId,
+            UUID centerId, VolunteerApplySearchCondition condition);
+
+}

--- a/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryUseCase.java
+++ b/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.somemore.volunteerapply.usecase;
 
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import java.util.List;
 import java.util.UUID;
@@ -11,5 +12,8 @@ public interface VolunteerApplyQueryUseCase {
 
     VolunteerApply getByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId);
 
-    VolunteerApplySummaryResponseDto getSummaryByRecruitBoardId(Long recruitBoardId);
+    VolunteerApplySummaryResponseDto getSummaryByRecruitId(Long recruitId);
+
+    VolunteerApplyResponseDto getVolunteerApplyByRecruitIdAndVolunteerId(Long recruitId,
+            UUID volunteerId);
 }

--- a/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryUseCase.java
+++ b/src/main/java/com/somemore/volunteerapply/usecase/VolunteerApplyQueryUseCase.java
@@ -1,10 +1,15 @@
 package com.somemore.volunteerapply.usecase;
 
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import java.util.List;
 import java.util.UUID;
 
 public interface VolunteerApplyQueryUseCase {
+
     List<UUID> getVolunteerIdsByRecruitIds(List<Long> recruitIds);
+
     VolunteerApply getByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId);
+
+    VolunteerApplySummaryResponseDto getSummaryByRecruitBoardId(Long recruitBoardId);
 }

--- a/src/test/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImplTest.java
+++ b/src/test/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImplTest.java
@@ -1,5 +1,14 @@
 package com.somemore.recruitboard.repository;
 
+import static com.somemore.common.fixture.CenterFixture.createCenter;
+import static com.somemore.common.fixture.LocalDateTimeFixture.createCurrentDateTime;
+import static com.somemore.common.fixture.LocationFixture.createLocation;
+import static com.somemore.common.fixture.RecruitBoardFixture.createCompletedRecruitBoard;
+import static com.somemore.common.fixture.RecruitBoardFixture.createRecruitBoard;
+import static com.somemore.recruitboard.domain.RecruitStatus.CLOSED;
+import static com.somemore.recruitboard.domain.VolunteerCategory.ADMINISTRATIVE_SUPPORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.somemore.IntegrationTestSupport;
 import com.somemore.center.domain.Center;
 import com.somemore.center.repository.CenterRepository;
@@ -13,6 +22,11 @@ import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardDetail;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
 import com.somemore.recruitboard.repository.mapper.RecruitBoardWithLocation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,21 +36,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static com.somemore.common.fixture.CenterFixture.createCenter;
-import static com.somemore.common.fixture.LocalDateTimeFixture.createCurrentDateTime;
-import static com.somemore.common.fixture.LocationFixture.createLocation;
-import static com.somemore.common.fixture.RecruitBoardFixture.createCompletedRecruitBoard;
-import static com.somemore.common.fixture.RecruitBoardFixture.createRecruitBoard;
-import static com.somemore.recruitboard.domain.RecruitStatus.CLOSED;
-import static com.somemore.recruitboard.domain.VolunteerCategory.ADMINISTRATIVE_SUPPORT;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
@@ -243,7 +242,8 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
         recruitBoardRepository.save(completedRecruitBoard);
 
         // when
-        List<Long> notCompletedBoardIds = recruitBoardRepository.findNotCompletedIdsByCenterId(centerId);
+        List<Long> notCompletedBoardIds = recruitBoardRepository.findNotCompletedIdsByCenterId(
+                centerId);
 
         // then
         assertThat(notCompletedBoardIds)
@@ -406,6 +406,24 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
 
         // then
         assertThat(results).isEmpty();
+    }
+
+    @DisplayName("아이디 리스트로 모집글을 조회할 수 있다.")
+    @Test
+    void findAllByIds() {
+        // given
+        RecruitBoard board1 = createRecruitBoard();
+        RecruitBoard board2 = createRecruitBoard();
+        RecruitBoard board3 = createRecruitBoard();
+
+        recruitBoardRepository.saveAll(List.of(board1, board2, board3));
+        List<Long> ids = List.of(board1.getId(), board2.getId(), board3.getId(), 100000L);
+
+        // when
+        List<RecruitBoard> all = recruitBoardRepository.findAllByIds(ids);
+
+        // then
+        assertThat(all).hasSize(3);
     }
 
     private Pageable getPageable() {

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
@@ -82,9 +82,9 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         // when
         // then
         assertThatThrownBy(
-            () -> recruitBoardQueryService.getRecruitBoardById(wrongId)
+                () -> recruitBoardQueryService.getRecruitBoardById(wrongId)
         ).isInstanceOf(BadRequestException.class)
-            .hasMessage(NOT_EXISTS_RECRUIT_BOARD.getMessage());
+                .hasMessage(NOT_EXISTS_RECRUIT_BOARD.getMessage());
     }
 
     @DisplayName("아이디로 모집글과 기관를 조회할 수 있다.")
@@ -99,7 +99,7 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
         // when
         RecruitBoardWithLocationResponseDto responseDto = recruitBoardQueryService.getWithLocationById(
-            board.getId());
+                board.getId());
 
         // then
         assertThat(responseDto.id()).isEqualTo(board.getId());
@@ -115,9 +115,9 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         // when
         // then
         assertThatThrownBy(
-            () -> recruitBoardQueryService.getWithLocationById(wrongId)
+                () -> recruitBoardQueryService.getWithLocationById(wrongId)
         ).isInstanceOf(BadRequestException.class)
-            .hasMessage(NOT_EXISTS_RECRUIT_BOARD.getMessage());
+                .hasMessage(NOT_EXISTS_RECRUIT_BOARD.getMessage());
     }
 
     @DisplayName("모집글과 기관 정보 리스트를 페이징 처리하여 받을 수 있다")
@@ -133,12 +133,12 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
-            .pageable(pageable)
-            .build();
+                .pageable(pageable)
+                .build();
 
         // when
         Page<RecruitBoardWithCenterResponseDto> dtos = recruitBoardQueryService.getAllWithCenter(
-            condition);
+                condition);
 
         // then
         assertThat(dtos).isNotEmpty();
@@ -160,15 +160,15 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
         Pageable pageable = getPageable();
         RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
-            .latitude(location.getLatitude().doubleValue())
-            .longitude(location.getLongitude().doubleValue())
-            .radius(3.0)
-            .pageable(pageable)
-            .build();
+                .latitude(location.getLatitude().doubleValue())
+                .longitude(location.getLongitude().doubleValue())
+                .radius(3.0)
+                .pageable(pageable)
+                .build();
 
         // when
         Page<RecruitBoardDetailResponseDto> result = recruitBoardQueryService.getRecruitBoardsNearby(
-            condition);
+                condition);
 
         // then
         assertThat(result).isNotEmpty();
@@ -190,12 +190,12 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         UUID centerId = center.getId();
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
-            .pageable(pageable)
-            .build();
+                .pageable(pageable)
+                .build();
 
         // when
         Page<RecruitBoardResponseDto> result = recruitBoardQueryService.getRecruitBoardsByCenterId(
-            centerId, condition);
+                centerId, condition);
 
         // then
         assertThat(result).isNotEmpty();
@@ -208,14 +208,14 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         // given
         UUID wrongCenterId = UUID.randomUUID();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
-            .build();
+                .build();
 
         // when
         // then
         assertThatThrownBy(
-            () -> recruitBoardQueryService.getRecruitBoardsByCenterId(wrongCenterId, condition))
-            .isInstanceOf(BadRequestException.class)
-            .hasMessage(NOT_EXISTS_CENTER.getMessage());
+                () -> recruitBoardQueryService.getRecruitBoardsByCenterId(wrongCenterId, condition))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(NOT_EXISTS_CENTER.getMessage());
     }
 
     @DisplayName("센터 ID로 완료되지 않은 모집 게시글들의 ID를 조회할 수 있다")
@@ -248,7 +248,8 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         recruitBoardRepository.save(completedRecruitBoard);
 
         // when
-        List<Long> notCompletedBoardIds = recruitBoardQueryService.getNotCompletedIdsByCenterIds(centerId);
+        List<Long> notCompletedBoardIds = recruitBoardQueryService.getNotCompletedIdsByCenterIds(
+                centerId);
 
         // then
         assertThat(notCompletedBoardIds)
@@ -259,6 +260,24 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
                 .doesNotContain(deletedClosedBoard.getId())
                 .doesNotContain(deletedCompletedRecruitBoard.getId())
                 .doesNotContain(completedRecruitBoard.getId());
+    }
+
+    @DisplayName("아이디리스트로 모집글 리스트를 조회할 수 있다.")
+    @Test
+    void getAllByIds() {
+        // given
+        RecruitBoard board1 = createRecruitBoard();
+        RecruitBoard board2 = createRecruitBoard();
+        RecruitBoard board3 = createRecruitBoard();
+
+        recruitBoardRepository.saveAll(List.of(board1, board2, board3));
+        List<Long> ids = List.of(board1.getId(), board2.getId(), board3.getId(), 100000L);
+
+        // when
+        List<RecruitBoard> all = recruitBoardQueryService.getAllByIds(ids);
+
+        // then
+        assertThat(all).hasSize(3);
     }
 
     private Pageable getPageable() {

--- a/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
+++ b/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
@@ -17,6 +17,7 @@ import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
+import com.somemore.volunteer.repository.mapper.VolunteerSimpleInfo;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -236,11 +237,11 @@ class VolunteerQueryServiceTest extends IntegrationTestSupport {
         volunteerDetailRepository.save(detail2);
 
         // when
-        List<VolunteerSimpleInfoResponseDto> dtos = volunteerQueryService.getVolunteerSimpleInfosByIds(
+        List<VolunteerSimpleInfo> volunteers = volunteerQueryService.getVolunteerSimpleInfosByIds(
                 List.of(volunteer1.getId(), volunteer2.getId(), UUID.randomUUID()));
 
         // then
-        assertThat(dtos).hasSize(2);
+        assertThat(volunteers).hasSize(2);
     }
 
     private static VolunteerDetail createVolunteerDetail(UUID volunteerId) {

--- a/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
+++ b/src/test/java/com/somemore/volunteer/service/VolunteerQueryServiceTest.java
@@ -1,5 +1,11 @@
 package com.somemore.volunteer.service;
 
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
+import static com.somemore.global.exception.ExceptionMessage.UNAUTHORIZED_VOLUNTEER_DETAIL;
+import static com.somemore.volunteer.domain.Volunteer.createDefault;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.somemore.IntegrationTestSupport;
 import com.somemore.auth.oauth.OAuthProvider;
 import com.somemore.global.exception.BadRequestException;
@@ -8,21 +14,15 @@ import com.somemore.volunteer.domain.VolunteerDetail;
 import com.somemore.volunteer.dto.request.VolunteerRegisterRequestDto;
 import com.somemore.volunteer.dto.response.VolunteerProfileResponseDto;
 import com.somemore.volunteer.dto.response.VolunteerRankingResponseDto;
+import com.somemore.volunteer.dto.response.VolunteerSimpleInfoResponseDto;
 import com.somemore.volunteer.repository.VolunteerDetailRepository;
 import com.somemore.volunteer.repository.VolunteerRepository;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER;
-import static com.somemore.global.exception.ExceptionMessage.UNAUTHORIZED_VOLUNTEER_DETAIL;
-import static com.somemore.volunteer.domain.Volunteer.createDefault;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 class VolunteerQueryServiceTest extends IntegrationTestSupport {
@@ -217,6 +217,30 @@ class VolunteerQueryServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(volunteers).hasSize(2);
+    }
+
+    @DisplayName("아이디 리스트로 봉사자 간단 정보를 조회할 수 있다")
+    @Test
+    void getVolunteerSimpleInfosByIds() {
+        // given
+        Volunteer volunteer1 = Volunteer.createDefault(OAuthProvider.NAVER, "1234");
+        Volunteer volunteer2 = Volunteer.createDefault(OAuthProvider.NAVER, "1234");
+
+        volunteerRepository.save(volunteer1);
+        volunteerRepository.save(volunteer2);
+
+        VolunteerDetail detail1 = createVolunteerDetail(volunteer1.getId());
+        VolunteerDetail detail2 = createVolunteerDetail(volunteer1.getId());
+
+        volunteerDetailRepository.save(detail1);
+        volunteerDetailRepository.save(detail2);
+
+        // when
+        List<VolunteerSimpleInfoResponseDto> dtos = volunteerQueryService.getVolunteerSimpleInfosByIds(
+                List.of(volunteer1.getId(), volunteer2.getId(), UUID.randomUUID()));
+
+        // then
+        assertThat(dtos).hasSize(2);
     }
 
     private static VolunteerDetail createVolunteerDetail(UUID volunteerId) {

--- a/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyCommandApiControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.somemore.ControllerTestSupport;
 import com.somemore.WithMockCustomUser;
-import com.somemore.volunteerapply.dto.VolunteerApplyCreateRequestDto;
+import com.somemore.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
 import com.somemore.volunteerapply.usecase.ApplyVolunteerApplyUseCase;
 import com.somemore.volunteerapply.usecase.WithdrawVolunteerApplyUseCase;
 import java.util.UUID;

--- a/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
@@ -11,9 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.somemore.ControllerTestSupport;
 import com.somemore.WithMockCustomUser;
 import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
-import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyRecruitInfoResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyVolunteerInfoResponseDto;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import java.util.Collections;
@@ -105,7 +106,7 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
     void getVolunteerApplies() throws Exception {
         // given
         Long recruitBoardId = 1L;
-        Page<VolunteerApplyDetailResponseDto> page = new PageImpl<>(Collections.emptyList());
+        Page<VolunteerApplyVolunteerInfoResponseDto> page = new PageImpl<>(Collections.emptyList());
 
         given(volunteerApplyQueryFacadeUseCase.getVolunteerAppliesByRecruitIdAndCenterId(
                 any(), any(UUID.class), any(VolunteerApplySearchCondition.class)))
@@ -113,7 +114,7 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
 
         // when
         // then
-        mockMvc.perform(get("/api/volunteer-applies//recruit-board/{id}", recruitBoardId)
+        mockMvc.perform(get("/api/volunteer-applies/recruit-board/{id}", recruitBoardId)
                         .param("attended", "false")
                         .param("status", WAITING.toString())
                         .accept(APPLICATION_JSON))
@@ -121,5 +122,28 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").exists())
                 .andExpect(jsonPath("$.message").value("지원자 리스트 조회 성공"));
+    }
+
+    @Test
+    @DisplayName("특정 봉사자 지원 리스트를 조회 성공 테스트")
+    void getVolunteerAppliesByVolunteerId() throws Exception {
+        // given
+        UUID volunteerId = UUID.randomUUID();
+        Page<VolunteerApplyRecruitInfoResponseDto> page = new PageImpl<>(Collections.emptyList());
+
+        given(volunteerApplyQueryFacadeUseCase.getVolunteerAppliesByVolunteerId(
+                any(UUID.class), any(VolunteerApplySearchCondition.class)))
+                .willReturn(page);
+
+        // when
+        // then
+        mockMvc.perform(get("/api/volunteer-applies/volunteer/{id}", volunteerId.toString())
+                        .param("attended", "false")
+                        .param("status", WAITING.toString())
+                        .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.message").value("봉사 지원 리스트 조회 성공"));
     }
 }

--- a/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
@@ -1,0 +1,52 @@
+package com.somemore.volunteerapply.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.somemore.ControllerTestSupport;
+import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
+
+    @DisplayName("모집글 지원자 통계 조회 성공 테스트")
+    @Test
+    void getSummaryByRecruitBoardId() throws Exception {
+        // given
+        Long recruitBoardId = 1L;
+        VolunteerApplySummaryResponseDto response = VolunteerApplySummaryResponseDto.builder()
+                .total(17L)
+                .waiting(5L)
+                .approve(10L)
+                .reject(2L)
+                .build();
+
+        given(volunteerApplyQueryUseCase.getSummaryByRecruitBoardId(recruitBoardId))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/volunteer-apply/recruit-board/{id}/summary", recruitBoardId)
+                        .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("지원자 통계 조회 성공"))
+                .andExpect(jsonPath("$.data.total").value(17))
+                .andExpect(jsonPath("$.data.waiting").value(5))
+                .andExpect(jsonPath("$.data.approve").value(10))
+                .andExpect(jsonPath("$.data.reject").value(2));
+    }
+}

--- a/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.somemore.volunteerapply.controller;
 
+import static com.somemore.volunteerapply.domain.ApplyStatus.WAITING;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -7,8 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.somemore.ControllerTestSupport;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.volunteerapply.usecase.VolunteerApplyQueryUseCase;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +26,40 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
     @MockBean
     private VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
 
+    @DisplayName("특정 모집글 봉사자 지원 단건 조회 성공 테스트")
+    @Test
+    void getVolunteerApplyByRecruitIdAndVolunteerId() throws Exception {
+        // given
+        Long recruitBoardId = 1L;
+        UUID volunteerId = UUID.randomUUID();
+
+        VolunteerApplyResponseDto response = VolunteerApplyResponseDto.builder()
+                .id(1L)
+                .volunteerId(volunteerId)
+                .recruitBoardId(recruitBoardId)
+                .status(WAITING)
+                .attended(false)
+                .build();
+
+        given(volunteerApplyQueryUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId,
+                volunteerId))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}",
+                                recruitBoardId, volunteerId)
+                                .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("특정 모집글에 대한 봉사자 지원 단건 조회 성공"))
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.volunteer_id").value(volunteerId.toString()))
+                .andExpect(jsonPath("$.data.recruit_board_id").value(recruitBoardId))
+                .andExpect(jsonPath("$.data.status").value("WAITING"))
+                .andExpect(jsonPath("$.data.attended").value(false));
+    }
+
     @DisplayName("모집글 지원자 통계 조회 성공 테스트")
     @Test
     void getSummaryByRecruitBoardId() throws Exception {
@@ -35,7 +72,7 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
                 .reject(2L)
                 .build();
 
-        given(volunteerApplyQueryUseCase.getSummaryByRecruitBoardId(recruitBoardId))
+        given(volunteerApplyQueryUseCase.getSummaryByRecruitId(recruitBoardId))
                 .willReturn(response);
 
         // when & then

--- a/src/test/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImplTest.java
+++ b/src/test/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImplTest.java
@@ -135,6 +135,19 @@ class VolunteerApplyRepositoryImplTest extends IntegrationTestSupport {
         assertThat(result).isTrue();
     }
 
+    @DisplayName("모집글 아이디로 지원 리스트를 조회할 수 있다.")
+    @Test
+    void findAllByRecruitIdNotPaging() {
+        // given
+        Long recruitBoardId = 1L;
+
+        // when
+        List<VolunteerApply> applies = volunteerApplyRepository.findAllByRecruitId(recruitBoardId);
+
+        // then
+        assertThat(applies).hasSize(15);
+    }
+
     private static VolunteerApply createApply(UUID volunteerId, Long recruitId) {
         return VolunteerApply.builder()
                 .volunteerId(volunteerId)

--- a/src/test/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImplTest.java
+++ b/src/test/java/com/somemore/volunteerapply/repository/VolunteerApplyRepositoryImplTest.java
@@ -182,6 +182,36 @@ class VolunteerApplyRepositoryImplTest extends IntegrationTestSupport {
 
     }
 
+    @DisplayName("봉사자 아이디와 조건 - 지원 상태, 참석 여부로 페이징 조회할 수 있다.")
+    @Test
+    void findAllByVolunteerId() {
+        // given
+        UUID centerId = UUID.randomUUID();
+        ApplyStatus status = APPROVED;
+        Boolean attended = false;
+
+        volunteerApplyRepository.save(createApply(centerId, status, attended));
+        volunteerApplyRepository.save(createApply(centerId, status, attended));
+        volunteerApplyRepository.save(createApply(centerId, status, attended));
+        volunteerApplyRepository.save(createApply(centerId, REJECTED, !attended));
+
+        VolunteerApplySearchCondition condition = VolunteerApplySearchCondition.builder()
+                .status(status)
+                .attended(attended)
+                .pageable(getPageable())
+                .build();
+
+        // when
+        Page<VolunteerApply> applies = volunteerApplyRepository.findAllByVolunteerId(centerId,
+                condition);
+
+        // then
+        assertThat(applies.getTotalElements()).isEqualTo(3);
+        assertThat(applies.getContent())
+                .allMatch(apply -> apply.getStatus() == APPROVED && !apply.getAttended());
+
+    }
+
     private static VolunteerApply createApply(UUID volunteerId, Long recruitId) {
         return VolunteerApply.builder()
                 .volunteerId(volunteerId)
@@ -196,6 +226,16 @@ class VolunteerApplyRepositoryImplTest extends IntegrationTestSupport {
         return VolunteerApply.builder()
                 .volunteerId(UUID.randomUUID())
                 .recruitBoardId(recruitId)
+                .status(status)
+                .attended(attended)
+                .build();
+    }
+
+    private static VolunteerApply createApply(UUID centerId, ApplyStatus status,
+            Boolean attended) {
+        return VolunteerApply.builder()
+                .volunteerId(centerId)
+                .recruitBoardId(101L)
                 .status(status)
                 .attended(attended)
                 .build();

--- a/src/test/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyServiceTest.java
@@ -19,7 +19,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class ApplyVolunteerApplyServiceTest extends IntegrationTestSupport {
 
     @Autowired

--- a/src/test/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/ApplyVolunteerApplyServiceTest.java
@@ -12,7 +12,7 @@ import com.somemore.global.exception.BadRequestException;
 import com.somemore.recruitboard.domain.RecruitBoard;
 import com.somemore.recruitboard.repository.RecruitBoardRepository;
 import com.somemore.volunteerapply.domain.VolunteerApply;
-import com.somemore.volunteerapply.dto.VolunteerApplyCreateRequestDto;
+import com.somemore.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyServiceTest.java
@@ -20,7 +20,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class ApproveVolunteerApplyServiceTest extends IntegrationTestSupport {
 
     @Autowired

--- a/src/test/java/com/somemore/volunteerapply/service/RejectVolunteerApplyServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/RejectVolunteerApplyServiceTest.java
@@ -20,7 +20,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RejectVolunteerApplyServiceTest extends IntegrationTestSupport {
 
     @Autowired

--- a/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeServiceTest.java
@@ -1,0 +1,108 @@
+package com.somemore.volunteerapply.service;
+
+import static com.somemore.auth.oauth.OAuthProvider.NAVER;
+import static com.somemore.volunteerapply.domain.ApplyStatus.APPROVED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.common.fixture.RecruitBoardFixture;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.repository.RecruitBoardRepository;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.domain.VolunteerDetail;
+import com.somemore.volunteer.dto.request.VolunteerRegisterRequestDto;
+import com.somemore.volunteer.repository.VolunteerDetailRepository;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.condition.VolunteerApplySearchCondition;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyDetailResponseDto;
+import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+class VolunteerApplyQueryFacadeServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private VolunteerApplyQueryFacadeService volunteerApplyQueryFacadeService;
+    @Autowired
+    private RecruitBoardRepository recruitBoardRepository;
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+    @Autowired
+    private VolunteerDetailRepository volunteerDetailRepository;
+    @Autowired
+    private VolunteerApplyRepository volunteerApplyRepository;
+
+
+    @DisplayName("모집글 아이디와 기관 아이디로 필터에 맞는 지원자 간단 정보를 조회할 수 있다.")
+    @Test
+    void getVolunteerAppliesByRecruitIdAndCenterId() {
+        // given
+        UUID centerId = UUID.randomUUID();
+        RecruitBoard board = RecruitBoardFixture.createRecruitBoard(centerId);
+        recruitBoardRepository.save(board);
+
+        Volunteer volunteer1 = Volunteer.createDefault(NAVER, "naver");
+        Volunteer volunteer2 = Volunteer.createDefault(NAVER, "naver");
+        volunteerRepository.save(volunteer1);
+        volunteerRepository.save(volunteer2);
+
+        VolunteerDetail volunteerDetail1 = createVolunteerDetail(volunteer1.getId());
+        VolunteerDetail volunteerDetail2 = createVolunteerDetail(volunteer2.getId());
+        volunteerDetailRepository.save(volunteerDetail1);
+        volunteerDetailRepository.save(volunteerDetail2);
+
+        VolunteerApply apply1 = createApply(volunteer1.getId(), board.getId());
+        VolunteerApply apply2 = createApply(volunteer2.getId(), board.getId());
+        volunteerApplyRepository.saveAll(List.of(apply1, apply2));
+
+        VolunteerApplySearchCondition condition = VolunteerApplySearchCondition.builder()
+                .pageable(getPageable())
+                .build();
+
+        // when
+        Page<VolunteerApplyDetailResponseDto> result = volunteerApplyQueryFacadeService.getVolunteerAppliesByRecruitIdAndCenterId(
+                board.getId(),
+                centerId, condition);
+
+        // then
+        assertThat(result).hasSize(2);
+
+    }
+
+    private static VolunteerDetail createVolunteerDetail(UUID volunteerId) {
+
+        VolunteerRegisterRequestDto volunteerRegisterRequestDto =
+                new VolunteerRegisterRequestDto(
+                        NAVER,
+                        "example-oauth-id",
+                        "making",
+                        "making@example.com",
+                        "male",
+                        "06-08",
+                        "1998",
+                        "010-1234-5678"
+                );
+
+        return VolunteerDetail.of(volunteerRegisterRequestDto, volunteerId);
+    }
+
+    private static VolunteerApply createApply(UUID volunteerId, Long recruitId) {
+        return VolunteerApply.builder()
+                .volunteerId(volunteerId)
+                .recruitBoardId(recruitId)
+                .status(APPROVED)
+                .attended(false)
+                .build();
+    }
+
+    private Pageable getPageable() {
+        return PageRequest.of(0, 4);
+    }
+}

--- a/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryFacadeServiceTest.java
@@ -26,7 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class VolunteerApplyQueryFacadeServiceTest extends IntegrationTestSupport {
 
     @Autowired

--- a/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryServiceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.somemore.IntegrationTestSupport;
 import com.somemore.volunteerapply.domain.ApplyStatus;
 import com.somemore.volunteerapply.domain.VolunteerApply;
+import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import java.util.List;
@@ -90,12 +91,31 @@ class VolunteerApplyQueryServiceTest extends IntegrationTestSupport {
         }
 
         // when
-        VolunteerApplySummaryResponseDto dto = volunteerApplyQueryService.getSummaryByRecruitBoardId(
+        VolunteerApplySummaryResponseDto dto = volunteerApplyQueryService.getSummaryByRecruitId(
                 recruitBoardId);
         // then
         assertThat(dto.waiting()).isEqualTo(waitingCount);
         assertThat(dto.approve()).isEqualTo(approveCount);
         assertThat(dto.reject()).isEqualTo(rejectCount);
+    }
+
+    @DisplayName("모집글 아이디와 봉사자 아이디로 지원 응답 값을 조회할 수 있다.")
+    @Test
+    void getVolunteerApplyByRecruitIdAndVolunteerId() {
+        // given
+        Long recruitId = 1234L;
+        UUID volunteerId = UUID.randomUUID();
+
+        VolunteerApply newApply = createApply(volunteerId, recruitId);
+        volunteerApplyRepository.save(newApply);
+
+        // when
+        VolunteerApplyResponseDto dto = volunteerApplyQueryService.getVolunteerApplyByRecruitIdAndVolunteerId(
+                recruitId, volunteerId);
+
+        // then
+        assertThat(dto.recruitBoardId()).isEqualTo(recruitId);
+        assertThat(dto.volunteerId()).isEqualTo(volunteerId);
     }
 
     private VolunteerApply createApply(UUID volunteerId, Long recruitId) {

--- a/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/VolunteerApplyQueryServiceTest.java
@@ -10,6 +10,7 @@ import com.somemore.volunteerapply.domain.ApplyStatus;
 import com.somemore.volunteerapply.domain.VolunteerApply;
 import com.somemore.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
+import com.somemore.volunteerapply.repository.VolunteerApplyJpaRepository;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import java.util.List;
 import java.util.UUID;

--- a/src/test/java/com/somemore/volunteerapply/service/WithdrawVolunteerApplyServiceTest.java
+++ b/src/test/java/com/somemore/volunteerapply/service/WithdrawVolunteerApplyServiceTest.java
@@ -15,7 +15,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class WithdrawVolunteerApplyServiceTest extends IntegrationTestSupport {
 
     @Autowired


### PR DESCRIPTION
resolved : 
 - #138
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 특정 봉사 활동에 대한 봉사자 지원 조회
- 봉사 활동 지원자 리스트 정보 조회 (기관)
- 특정 봉사자가 지원한 봉사 리스트 조회
- 봉사 활동 지원자 통계 조회

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
`VolunteerApplyQueryFacadeService` 한번씩 봐주시면 감사하겠습니다.
- 원래 `VolunteerApplyQueryService` 에서 아래를 구현하려함
  - 특정 봉사자 지원 리스트 기능 -> 'VolunteerQueryUseCase' 의존
  - 특정 봉사 활동에 대한 지원자 리스트 기능 -> 'RecruitBoardQueryUseCase' 의존
-> 순환 참조 문제가 발생해서 파사드를 만들었습니다.