### PR TITLE
feat/175: AccessToken으로 만들어진 SCH의 Authentication으로부터 userId와 role 조회

### DIFF
--- a/src/main/java/com/somemore/auth/controller/UserInfoQueryController.java
+++ b/src/main/java/com/somemore/auth/controller/UserInfoQueryController.java
@@ -1,0 +1,35 @@
+package com.somemore.auth.controller;
+
+import com.somemore.auth.dto.UserInfoResponseDto;
+import com.somemore.global.common.response.ApiResponse;
+import com.somemore.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.somemore.global.exception.ExceptionMessage.INVALID_TOKEN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+public class UserInfoQueryController {
+
+    @GetMapping("/userinfo")
+    public ApiResponse<UserInfoResponseDto> getUserInfoBySCH() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String userId = authentication.getPrincipal().toString();
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElseThrow(() -> new BadRequestException(INVALID_TOKEN));
+
+        return ApiResponse.ok(200,
+                new UserInfoResponseDto(userId, role),
+                "유저 정보 응답 성공");
+    }
+}

--- a/src/main/java/com/somemore/auth/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/somemore/auth/dto/UserInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.somemore.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 정보 DTO")
+public record UserInfoResponseDto(
+        @JsonProperty("USER_ID")
+        @Schema(description = "유저 ID")
+        String userId,
+
+        @JsonProperty("ROLE")
+        @Schema(description = "유저 ROLE")
+        String role
+) {
+}

--- a/src/main/java/com/somemore/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/somemore/global/exception/ExceptionMessage.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionMessage {
 
+    INVALID_TOKEN("잘못된 엑세스 토큰입니다"),
     NOT_EXISTS_CENTER("존재하지 않는 기관입니다."),
     NOT_EXISTS_COMMUNITY_BOARD("존재하지 않는 게시글입니다."),
     UNAUTHORIZED_COMMUNITY_BOARD("해당 게시글에 권한이 없습니다."),


### PR DESCRIPTION
resolved : 
- #175 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Header의 Authorization 값에 담긴 AccessToken으로부터 USER_ID와 ROLE을 발급해야 합니다.  
Cookie의 AccessToken이 HttpOnly로 관리되기를 원했기 때문에 JavaScript로 이를 직접 다룰 수 없어, 이를 처리하기 위한 별도의 컨트롤러를 제공해야 했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘게 쪼개고, Commit 별로 설명해주세요 -->
- AccessToken으로 만들어진 SecurityContextHolder의 Authentication으로부터 USER_ID와 ROLE을 조회하도록 구현했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 어노테이션을 활용해 USER_ROLE을 직접 얻는 방법을 찾지 못한 점이 아쉬웠습니다.  
  그래서 SecurityContextHolder에서 Authentication 객체를 가져오는 방식을 사용했습니다.  
- Auth 패키지에 별도의 컨트롤러를 추가했습니다.  
  이는 기관과 봉사자 모두를 조회해야 했고, 단일 요청으로 응답을 제공할 필요가 있었기 때문입니다.