### PR TITLE
Fix/178 AccessToken의 Bearer 키워드 문제 해결

### DIFF
--- a/src/main/java/com/somemore/auth/controller/UserInfoQueryController.java
+++ b/src/main/java/com/somemore/auth/controller/UserInfoQueryController.java
@@ -1,0 +1,35 @@
+package com.somemore.auth.controller;
+
+import com.somemore.auth.dto.UserInfoResponseDto;
+import com.somemore.global.common.response.ApiResponse;
+import com.somemore.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.somemore.global.exception.ExceptionMessage.INVALID_TOKEN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+public class UserInfoQueryController {
+
+    @GetMapping("/userinfo")
+    public ApiResponse<UserInfoResponseDto> getUserInfoBySCH() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String userId = authentication.getPrincipal().toString();
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElseThrow(() -> new BadRequestException(INVALID_TOKEN));
+
+        return ApiResponse.ok(200,
+                new UserInfoResponseDto(userId, role),
+                "유저 정보 응답 성공");
+    }
+}

--- a/src/main/java/com/somemore/auth/cookie/CookieService.java
+++ b/src/main/java/com/somemore/auth/cookie/CookieService.java
@@ -12,19 +12,17 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CookieService implements CookieUseCase {
 
-    private static final String ACCESS_TOKEN_PREFIX = "Bearer ";
-
     @Override
     public void setAccessToken(HttpServletResponse response, String value) {
         ResponseCookie cookie = generateCookie(TokenType.ACCESS, value);
-        response.addHeader("Set-Cookie", ACCESS_TOKEN_PREFIX + cookie);
+        response.addHeader("Set-Cookie", cookie.toString());
         log.info("SET_COOKIE_ACCESS_TOKEN = {}", value);
     }
 
     @Override
     public void deleteAccessToken(HttpServletResponse response) {
         ResponseCookie cookie = generateCookie(TokenType.SIGNOUT, TokenType.SIGNOUT.name());
-        response.addHeader("Set-Cookie", ACCESS_TOKEN_PREFIX + cookie);
+        response.addHeader("Set-Cookie", cookie.toString());
         log.info("DELETE_COOKIE_ACCESS_TOKEN");
     }
 

--- a/src/main/java/com/somemore/auth/cookie/CookieService.java
+++ b/src/main/java/com/somemore/auth/cookie/CookieService.java
@@ -12,17 +12,19 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CookieService implements CookieUseCase {
 
+    private static final String ACCESS_TOKEN_PREFIX = "Bearer ";
+
     @Override
     public void setAccessToken(HttpServletResponse response, String value) {
         ResponseCookie cookie = generateCookie(TokenType.ACCESS, value);
-        response.addHeader("Set-Cookie", cookie.toString());
+        response.addHeader("Set-Cookie", ACCESS_TOKEN_PREFIX + cookie);
         log.info("SET_COOKIE_ACCESS_TOKEN = {}", value);
     }
 
     @Override
     public void deleteAccessToken(HttpServletResponse response) {
         ResponseCookie cookie = generateCookie(TokenType.SIGNOUT, TokenType.SIGNOUT.name());
-        response.addHeader("Set-Cookie", cookie.toString());
+        response.addHeader("Set-Cookie", ACCESS_TOKEN_PREFIX + cookie);
         log.info("DELETE_COOKIE_ACCESS_TOKEN");
     }
 

--- a/src/main/java/com/somemore/auth/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/somemore/auth/dto/UserInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.somemore.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 정보 DTO")
+public record UserInfoResponseDto(
+        @JsonProperty("USER_ID")
+        @Schema(description = "유저 ID")
+        String userId,
+
+        @JsonProperty("ROLE")
+        @Schema(description = "유저 ROLE")
+        String role
+) {
+}

--- a/src/main/java/com/somemore/auth/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/somemore/auth/jwt/filter/JwtAuthFilter.java
@@ -55,13 +55,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private EncodedToken getAccessToken(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new JwtException(JwtErrorType.MISSING_TOKEN);
+        }
 
         String tokenPrefix = "Bearer ";
         if (accessToken.startsWith(tokenPrefix)) {
             return new EncodedToken(accessToken.substring(tokenPrefix.length()));
         }
 
-        throw new JwtException(JwtErrorType.MISSING_TOKEN);
+        return new EncodedToken(accessToken);
     }
 
     private JwtAuthenticationToken createAuthenticationToken(Claims claims,

--- a/src/main/java/com/somemore/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/somemore/global/exception/ExceptionMessage.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ExceptionMessage {
 
+    INVALID_TOKEN("잘못된 엑세스 토큰입니다"),
     NOT_EXISTS_CENTER("존재하지 않는 기관입니다."),
     NOT_EXISTS_COMMUNITY_BOARD("존재하지 않는 게시글입니다."),
     UNAUTHORIZED_COMMUNITY_BOARD("해당 게시글에 권한이 없습니다."),


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
resolved : 
- #178 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
AccessToken을 쿠키에 설정해 줄 때, httpOnly로 설정되어 프론트에서 이를 헤더에 담을 수만 있고 Prefix를 설정할 수 없습니다.
Bearer 키워드(공백 유의)가 문제가 되는데 이를 JwtFilter에서 핸들링하겠습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Bearer 키워드 유무에 따른 토큰 핸들링

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 쿠키에는 `Bearer ` 키워드가 설정될 수 없습니다. 띄어쓰기가 있는 것이 쿠키 정책에 올바르지 않아서 인코딩이 필요했고, 이를 해결하기 위해서 prefix 조건문을 추가했습니다.
- 기존 로직에도, 클라이언트 변경 요청에도 알맞은 결과를 반환합니다.
