### PR TITLE
feat 182/ cookie의 accessToken 추출

### DIFF
--- a/src/main/java/com/somemore/auth/jwt/domain/EncodedToken.java
+++ b/src/main/java/com/somemore/auth/jwt/domain/EncodedToken.java
@@ -1,4 +1,17 @@
 package com.somemore.auth.jwt.domain;
 
 public record EncodedToken(String value) {
+
+    public boolean isUninitialized() {
+        return value == null
+                || value.isEmpty()
+                || value.equals("UNINITIALIZED");
+    }
+
+    public EncodedToken removePrefix(String prefix) {
+        if (this.value.startsWith(prefix)) {
+            return new EncodedToken(this.value.substring(prefix.length()));
+        }
+        return this;
+    }
 }

--- a/src/main/java/com/somemore/auth/jwt/filter/JwtAuthFilter.java
+++ b/src/main/java/com/somemore/auth/jwt/filter/JwtAuthFilter.java
@@ -61,7 +61,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         EncodedToken accessToken = findAccessTokenFromCookie(request);
 
         if (accessToken.isUninitialized()) {
-            accessToken = new EncodedToken(request.getHeader("Authorization"));
+            accessToken = findAccessTokenFromHeader(request);
         }
 
         if (accessToken.isUninitialized()) {
@@ -70,6 +70,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String prefix = "Bearer ";
         return accessToken.removePrefix(prefix);
+    }
+
+    private static EncodedToken findAccessTokenFromHeader(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+            return new EncodedToken("UNINITIALIZED");
+        }
+
+        return new EncodedToken(authorizationHeader);
     }
 
     private EncodedToken findAccessTokenFromCookie(HttpServletRequest request) {


### PR DESCRIPTION
resolved : 
- #182 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
쿠키에서 accessToken을 추출할 수 있습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 쿠키와 헤더 모두에서 토큰을 추출할 수 있음.
  - 쿠키에서 토큰을 초기화하지 못하면 헤더에서 토큰을 찾음.
  - 헤더에서 토큰을 찾는 이유는 스웨거, 디버깅.

- accessToken 리팩토링.

- 쿠키 NPE 예방.
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
accessToken 초기화 흐름에 집중해 주세요!