### PR TITLE
Feature/189 봉사 후기 요청 이벤트, 알림

### DIFF
--- a/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
+++ b/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
@@ -21,10 +21,10 @@ public class VolunteerReviewRequestEvent extends ServerEvent<NotificationSubType
 
     @JsonCreator
     public VolunteerReviewRequestEvent(
-            @JsonProperty("volunteerId") UUID volunteerId,
-            @JsonProperty("volunteerApplyId") Long volunteerApplyId,
-            @JsonProperty("centerId") UUID centerId,
-            @JsonProperty("recruitBoardId") Long recruitBoardId
+            @JsonProperty(value = "volunteerId", required = true) UUID volunteerId,
+            @JsonProperty(value = "volunteerApplyId", required = true) Long volunteerApplyId,
+            @JsonProperty(value = "centerId", required = true) UUID centerId,
+            @JsonProperty(value = "recruitBoardId", required = true) Long recruitBoardId
     ) {
         super(ServerEventType.NOTIFICATION, NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE, LocalDateTime.now());
         this.volunteerId = volunteerId;

--- a/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
+++ b/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
@@ -1,0 +1,35 @@
+package com.somemore.facade.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.somemore.global.common.event.ServerEvent;
+import com.somemore.global.common.event.ServerEventType;
+import com.somemore.notification.domain.NotificationSubType;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@SuperBuilder
+public class VolunteerReviewRequestEvent extends ServerEvent<NotificationSubType> {
+    private final UUID volunteerId;
+    private final Long volunteerApplyId;
+    private final UUID centerId;
+    private final Long recruitBoardId;
+
+    @JsonCreator
+    public VolunteerReviewRequestEvent(
+            @JsonProperty("receiverId") UUID volunteerId,
+            @JsonProperty("volunteerApplyId") Long volunteerApplyId,
+            @JsonProperty("centerId") UUID centerId,
+            @JsonProperty("recruitBoardId") Long recruitBoardId
+    ) {
+        super(ServerEventType.NOTIFICATION, NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE, LocalDateTime.now());
+        this.volunteerId = volunteerId;
+        this.volunteerApplyId = volunteerApplyId;
+        this.centerId = centerId;
+        this.recruitBoardId = recruitBoardId;
+    }
+}

--- a/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
+++ b/src/main/java/com/somemore/facade/event/VolunteerReviewRequestEvent.java
@@ -21,7 +21,7 @@ public class VolunteerReviewRequestEvent extends ServerEvent<NotificationSubType
 
     @JsonCreator
     public VolunteerReviewRequestEvent(
-            @JsonProperty("receiverId") UUID volunteerId,
+            @JsonProperty("volunteerId") UUID volunteerId,
             @JsonProperty("volunteerApplyId") Long volunteerApplyId,
             @JsonProperty("centerId") UUID centerId,
             @JsonProperty("recruitBoardId") Long recruitBoardId

--- a/src/main/java/com/somemore/global/common/event/ServerEvent.java
+++ b/src/main/java/com/somemore/global/common/event/ServerEvent.java
@@ -20,9 +20,9 @@ public abstract class ServerEvent<T extends Enum<T>> {
     private final LocalDateTime createdAt;
 
     protected ServerEvent(
-            @JsonProperty("type") ServerEventType type,
-            @JsonProperty("subType") T subType,
-            @JsonProperty("createdAt") LocalDateTime createdAt
+            @JsonProperty(value = "type", required = true) ServerEventType type,
+            @JsonProperty(value = "subType", required = true) T subType,
+            @JsonProperty(value = "createdAt", required = true) LocalDateTime createdAt
     ) {
         this.type = type;
         this.subType = subType;

--- a/src/main/java/com/somemore/notification/converter/MessageConverter.java
+++ b/src/main/java/com/somemore/notification/converter/MessageConverter.java
@@ -1,6 +1,7 @@
 package com.somemore.notification.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.somemore.facade.event.VolunteerReviewRequestEvent;
@@ -46,7 +47,7 @@ public class MessageConverter {
                 .build();
     }
 
-    private Notification buildVolunteerApplyStatusChangeNotification(String message) throws Exception {
+    private Notification buildVolunteerApplyStatusChangeNotification(String message) throws JsonProcessingException {
         VolunteerApplyStatusChangeEvent event = objectMapper.readValue(message, VolunteerApplyStatusChangeEvent.class);
 
         return Notification.builder()

--- a/src/main/java/com/somemore/notification/domain/NotificationSubType.java
+++ b/src/main/java/com/somemore/notification/domain/NotificationSubType.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum NotificationSubType {
     NOTE_BLAH_BLAH("쪽지"),
-    REVIEW_BLAH_BLAH("후기 요청"),
+    VOLUNTEER_REVIEW_REQUEST("봉사 후기 요청"),
     VOLUNTEER_APPLY_STATUS_CHANGE("신청 상태 변경")
     ;
 

--- a/src/main/java/com/somemore/notification/handler/NotificationHandlerImpl.java
+++ b/src/main/java/com/somemore/notification/handler/NotificationHandlerImpl.java
@@ -8,9 +8,11 @@ import com.somemore.sse.domain.SseEventType;
 import com.somemore.sse.usecase.SseUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional
 public class NotificationHandlerImpl implements NotificationHandler {
 
     private final NotificationRepository notificationRepository;

--- a/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
+++ b/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
@@ -25,7 +25,7 @@ public class VolunteerApplyStatusChangeEvent extends ServerEvent<NotificationSub
 
     @JsonCreator
     public VolunteerApplyStatusChangeEvent(
-            @JsonProperty("receiverId") UUID volunteerId,
+            @JsonProperty("volunteerId") UUID volunteerId,
             @JsonProperty("volunteerApplyId") Long volunteerApplyId,
             @JsonProperty("centerId") UUID centerId,
             @JsonProperty("recruitBoardId") Long recruitBoardId,

--- a/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
+++ b/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @SuperBuilder
 public class VolunteerApplyStatusChangeEvent extends ServerEvent<NotificationSubType> {
 
-    private final UUID receiverId;
+    private final UUID volunteerId;
     private final Long volunteerApplyId;
     private final UUID centerId;
     private final Long recruitBoardId;
@@ -25,7 +25,7 @@ public class VolunteerApplyStatusChangeEvent extends ServerEvent<NotificationSub
 
     @JsonCreator
     public VolunteerApplyStatusChangeEvent(
-            @JsonProperty("receiverId") UUID receiverId,
+            @JsonProperty("receiverId") UUID volunteerId,
             @JsonProperty("volunteerApplyId") Long volunteerApplyId,
             @JsonProperty("centerId") UUID centerId,
             @JsonProperty("recruitBoardId") Long recruitBoardId,
@@ -33,7 +33,7 @@ public class VolunteerApplyStatusChangeEvent extends ServerEvent<NotificationSub
             @JsonProperty("newStatus") ApplyStatus newStatus
     ) {
         super(ServerEventType.NOTIFICATION, NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE, LocalDateTime.now());
-        this.receiverId = receiverId;
+        this.volunteerId = volunteerId;
         this.volunteerApplyId = volunteerApplyId;
         this.centerId = centerId;
         this.recruitBoardId = recruitBoardId;

--- a/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
+++ b/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
@@ -25,12 +25,12 @@ public class VolunteerApplyStatusChangeEvent extends ServerEvent<NotificationSub
 
     @JsonCreator
     public VolunteerApplyStatusChangeEvent(
-            @JsonProperty("volunteerId") UUID volunteerId,
-            @JsonProperty("volunteerApplyId") Long volunteerApplyId,
-            @JsonProperty("centerId") UUID centerId,
-            @JsonProperty("recruitBoardId") Long recruitBoardId,
-            @JsonProperty("oldStatus") ApplyStatus oldStatus,
-            @JsonProperty("newStatus") ApplyStatus newStatus
+            @JsonProperty(value = "volunteerId", required = true) UUID volunteerId,
+            @JsonProperty(value = "volunteerApplyId", required = true) Long volunteerApplyId,
+            @JsonProperty(value = "centerId", required = true) UUID centerId,
+            @JsonProperty(value = "recruitBoardId", required = true) Long recruitBoardId,
+            @JsonProperty(value = "oldStatus", required = true) ApplyStatus oldStatus,
+            @JsonProperty(value = "newStatus", required = true) ApplyStatus newStatus
     ) {
         super(ServerEventType.NOTIFICATION, NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE, LocalDateTime.now());
         this.volunteerId = volunteerId;

--- a/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
+++ b/src/main/java/com/somemore/volunteerapply/event/VolunteerApplyStatusChangeEvent.java
@@ -1,10 +1,11 @@
-package com.somemore.volunteerapply.domain;
+package com.somemore.volunteerapply.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.somemore.global.common.event.ServerEvent;
 import com.somemore.global.common.event.ServerEventType;
 import com.somemore.notification.domain.NotificationSubType;
+import com.somemore.volunteerapply.domain.ApplyStatus;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 

--- a/src/main/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyService.java
@@ -7,7 +7,7 @@ import com.somemore.notification.domain.NotificationSubType;
 import com.somemore.recruitboard.domain.RecruitBoard;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
 import com.somemore.volunteerapply.domain.VolunteerApply;
-import com.somemore.volunteerapply.domain.VolunteerApplyStatusChangeEvent;
+import com.somemore.volunteerapply.event.VolunteerApplyStatusChangeEvent;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.volunteerapply.usecase.ApproveVolunteerApplyUseCase;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyService.java
+++ b/src/main/java/com/somemore/volunteerapply/service/ApproveVolunteerApplyService.java
@@ -6,6 +6,7 @@ import com.somemore.global.exception.BadRequestException;
 import com.somemore.notification.domain.NotificationSubType;
 import com.somemore.recruitboard.domain.RecruitBoard;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
+import com.somemore.volunteerapply.domain.ApplyStatus;
 import com.somemore.volunteerapply.domain.VolunteerApply;
 import com.somemore.volunteerapply.event.VolunteerApplyStatusChangeEvent;
 import com.somemore.volunteerapply.repository.VolunteerApplyRepository;
@@ -38,10 +39,11 @@ public class ApproveVolunteerApplyService implements ApproveVolunteerApplyUseCas
         validateWriter(recruitBoard, centerId);
         validateBoardStatus(recruitBoard);
 
+        ApplyStatus oldStatus = apply.getStatus();
         apply.changeStatus(APPROVED);
         volunteerApplyRepository.save(apply);
 
-        publishVolunteerApplyStatusChangeEvent(apply.getVolunteerId(), id, recruitBoard, apply);
+        publishVolunteerApplyStatusChangeEvent(apply, recruitBoard, oldStatus);
     }
 
     private VolunteerApply getVolunteerApply(Long id) {
@@ -63,14 +65,15 @@ public class ApproveVolunteerApplyService implements ApproveVolunteerApplyUseCas
         }
     }
 
-    private void publishVolunteerApplyStatusChangeEvent(UUID receiverId, Long id, RecruitBoard recruitBoard, VolunteerApply apply) {
+    private void publishVolunteerApplyStatusChangeEvent(VolunteerApply apply, RecruitBoard recruitBoard, ApplyStatus oldStatus) {
         VolunteerApplyStatusChangeEvent event = VolunteerApplyStatusChangeEvent.builder()
                 .type(ServerEventType.NOTIFICATION)
                 .subType(NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE)
-                .receiverId(receiverId)
-                .volunteerApplyId(id)
+                .volunteerId(apply.getVolunteerId())
+                .volunteerApplyId(apply.getId())
                 .centerId(recruitBoard.getCenterId())
                 .recruitBoardId(recruitBoard.getId())
+                .oldStatus(oldStatus)
                 .newStatus(apply.getStatus())
                 .build();
 

--- a/src/test/java/com/somemore/notification/converter/MessageConverterTest.java
+++ b/src/test/java/com/somemore/notification/converter/MessageConverterTest.java
@@ -1,0 +1,104 @@
+package com.somemore.notification.converter;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.notification.domain.Notification;
+import com.somemore.notification.domain.NotificationSubType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MessageConverterTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MessageConverter messageConverter;
+
+    @Test
+    @DisplayName("VOLUNTEER_REVIEW_REQUEST 메시지를 변환하면 Notification 객체를 반환한다")
+    void testVolunteerReviewRequestConversion() {
+        // given
+        String message = """
+                {
+                    "type": "NOTIFICATION",
+                    "subType": "VOLUNTEER_REVIEW_REQUEST",
+                    "volunteerId": "123e4567-e89b-12d3-a456-426614174000",
+                    "volunteerApplyId": "1",
+                    "centerId": "123e4567-e89b-12d3-a456-426614174001",
+                    "recruitBoardId": 456,
+                    "createdAt": "2024-12-05T10:00:00"
+                }
+                """;
+
+        // when
+        Notification notification = messageConverter.from(message);
+
+        // then
+        assertThat(notification.getReceiverId()).isEqualTo(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+        assertThat(notification.getTitle()).isEqualTo("최근 활동하신 활동의 후기를 작성해 주세요!");
+        assertThat(notification.getType()).isEqualTo(NotificationSubType.VOLUNTEER_REVIEW_REQUEST);
+        assertThat(notification.getRelatedId()).isEqualTo(456L);
+    }
+
+    @Test
+    @DisplayName("임의의 필드가 추가된 VOLUNTEER_APPLY_STATUS_CHANGE 메시지를 변환해도 Notification 객체를 반환한다")
+    void testVolunteerApplyStatusChangeConversion() {
+        // given
+        String message = """
+                {
+                    "extraField": "this should be ignored",
+                    "extraField": "this should be ignored",
+                    "extraField": "this should be ignored",
+                    "extraField": "this should be ignored",
+                    "extraField": "this should be ignored",
+                    "type": "NOTIFICATION",
+                    "subType": "VOLUNTEER_APPLY_STATUS_CHANGE",
+                    "volunteerId": "123e4567-e89b-12d3-a456-426614174000",
+                    "centerId": "123e4567-e89b-12d3-a456-426614174001",
+                    "volunteerApplyId": "1",
+                    "recruitBoardId": 456,
+                    "oldStatus": "WAITING",
+                    "newStatus": "APPROVED",
+                    "createdAt": "2024-12-05T10:00:00"
+                }
+                """;
+
+        // when
+        Notification notification = messageConverter.from(message);
+
+        // then
+        assertThat(notification.getReceiverId()).isEqualTo(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+        assertThat(notification.getTitle()).isEqualTo("봉사 활동 신청이 승인되었습니다.");
+        assertThat(notification.getType()).isEqualTo(NotificationSubType.VOLUNTEER_APPLY_STATUS_CHANGE);
+        assertThat(notification.getRelatedId()).isEqualTo(456L);
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 메시지를 변환하면 IllegalStateException을 던진다")
+    void testInvalidJson() {
+        // given
+        String invalidMessage = "{ invalid-json }";
+
+        // when
+        // then
+        assertThrows(IllegalStateException.class, () -> messageConverter.from(invalidMessage));
+    }
+
+    @Test
+    @DisplayName("필수 필드가 누락된 메시지를 변환하면 IllegalStateException을 던진다")
+    void testMissingFields() {
+        // given
+        String messageWithMissingFields = """
+                {
+                    "type": "NOTIFICATION",
+                    "subType": "VOLUNTEER_REVIEW_REQUEST"
+                }
+                """;
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> messageConverter.from(messageWithMissingFields));
+    }
+}

--- a/src/test/java/com/somemore/notification/handler/NotificationHandlerTest.java
+++ b/src/test/java/com/somemore/notification/handler/NotificationHandlerTest.java
@@ -61,5 +61,7 @@ class NotificationHandlerTest extends IntegrationTestSupport {
         assertThat(savedNotification.getRelatedId()).isEqualTo(456L); // 프론트 요구사항: 123L(봉사신청아이디), 456L(모집글아이디)
         assertThat(savedNotification.isRead()).isFalse();
         assertThat(savedNotification.getCreatedAt()).isEqualTo(notification.getCreatedAt());
+        assertThat(savedNotification.getCreatedAt()).isNotNull();
     }
+
 }

--- a/src/test/java/com/somemore/notification/handler/NotificationHandlerTest.java
+++ b/src/test/java/com/somemore/notification/handler/NotificationHandlerTest.java
@@ -35,10 +35,11 @@ class NotificationHandlerTest extends IntegrationTestSupport {
                 {
                     "type": "NOTIFICATION",
                     "subType": "VOLUNTEER_APPLY_STATUS_CHANGE",
-                    "receiverId": "123e4567-e89b-12d3-a456-426614174000",
+                    "volunteerId": "123e4567-e89b-12d3-a456-426614174000",
                     "volunteerApplyId": 123,
                     "centerId": "123e4567-e89b-12d3-a456-426614174001",
                     "recruitBoardId": 456,
+                    "oldStatus": "WAITING",
                     "newStatus": "APPROVED",
                     "createdAt": "2024-12-05T10:00:00"
                 }

--- a/src/test/java/com/somemore/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/somemore/notification/service/NotificationCommandServiceTest.java
@@ -126,7 +126,7 @@ class NotificationCommandServiceTest extends IntegrationTestSupport {
         return Notification.builder()
                 .receiverId(receiverId)
                 .title("Unread")
-                .type(NotificationSubType.REVIEW_BLAH_BLAH)
+                .type(NotificationSubType.VOLUNTEER_REVIEW_REQUEST)
                 .relatedId(1L)
                 .build();
     }

--- a/src/test/java/com/somemore/notification/service/NotificationQueryServiceTest.java
+++ b/src/test/java/com/somemore/notification/service/NotificationQueryServiceTest.java
@@ -55,7 +55,7 @@ class NotificationQueryServiceTest extends IntegrationTestSupport {
 
         Notification readNotification = Notification.builder()
                 .title("Read Notification")
-                .type(NotificationSubType.REVIEW_BLAH_BLAH)
+                .type(NotificationSubType.VOLUNTEER_REVIEW_REQUEST)
                 .receiverId(receiverId)
                 .relatedId(2L)
                 .build();


### PR DESCRIPTION
resolved : 
- #189 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
봉사 정산이 완료된 후, 유저가 후기를 작성할 수 있는 상태가 되면 봉사 후기 요청 이벤트가 발생합니다.
이 이벤트는 Redis Pub/Sub과 SSE를 통해 클라이언트에게 전달되며, 전체 흐름은 다음과 같습니다:
1. 이벤트 발행 (Pub)
- VolunteerReviewRequestEvent를 직렬화하여 Redis의 Pub 채널(Notification topic)로 발행. 
2. 이벤트 수신 (Sub)
- Redis Sub 채널(Notification topic)에서 수신된 메시지를 VolunteerReviewRequestEvent 타입으로 역직렬화.
- VolunteerReviewRequestEvent 타입을 Notification 으로 컨버팅.(서브타입이 **volunteerReviewRequest**로 분류됨.)
3. SSE를 통한 알림 전송
- 서브타입에 따라 생성된 알림을 DB에 저장하고, receiverId 기준으로 SSE를 통해 클라이언트에 전달.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 이벤트 pub/sub
- 알림 sse
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
