### PR TITLE
Feature/204 댓글 알림

### DIFF
--- a/src/main/java/com/somemore/community/event/CommentAddedEvent.java
+++ b/src/main/java/com/somemore/community/event/CommentAddedEvent.java
@@ -1,0 +1,30 @@
+package com.somemore.community.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.somemore.global.common.event.ServerEvent;
+import com.somemore.global.common.event.ServerEventType;
+import com.somemore.notification.domain.NotificationSubType;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@SuperBuilder
+public class CommentAddedEvent extends ServerEvent<NotificationSubType> {
+
+    private final UUID volunteerId;
+    private final Long communityBoardId;
+
+    @JsonCreator
+    public CommentAddedEvent(
+            @JsonProperty(value = "volunteerId", required = true) UUID volunteerId,
+            @JsonProperty(value = "communityBoardId", required = true) Long communityBoardId
+    ) {
+        super(ServerEventType.NOTIFICATION, NotificationSubType.COMMENT_ADDED, LocalDateTime.now());
+        this.volunteerId = volunteerId;
+        this.communityBoardId = communityBoardId;
+    }
+}

--- a/src/main/java/com/somemore/community/service/comment/CreateCommunityCommentService.java
+++ b/src/main/java/com/somemore/community/service/comment/CreateCommunityCommentService.java
@@ -2,10 +2,15 @@ package com.somemore.community.service.comment;
 
 import com.somemore.community.domain.CommunityComment;
 import com.somemore.community.dto.request.CommunityCommentCreateRequestDto;
+import com.somemore.community.event.CommentAddedEvent;
 import com.somemore.community.repository.board.CommunityBoardRepository;
 import com.somemore.community.repository.comment.CommunityCommentRepository;
 import com.somemore.community.usecase.comment.CreateCommunityCommentUseCase;
+import com.somemore.global.common.event.ServerEventPublisher;
+import com.somemore.global.common.event.ServerEventType;
 import com.somemore.global.exception.BadRequestException;
+import com.somemore.notification.domain.NotificationSubType;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +27,7 @@ public class CreateCommunityCommentService implements CreateCommunityCommentUseC
 
     private final CommunityBoardRepository communityBoardRepository;
     private final CommunityCommentRepository communityCommentRepository;
+    private final ServerEventPublisher serverEventPublisher;
 
     @Override
     public Long createCommunityComment(CommunityCommentCreateRequestDto requestDto, UUID writerId, Long communityBoardId) {
@@ -33,6 +39,7 @@ public class CreateCommunityCommentService implements CreateCommunityCommentUseC
             validateParentCommentExists(communityComment.getParentCommentId());
         }
 
+        publishCommentAddedEvent(communityComment);
         return communityCommentRepository.save(communityComment).getId();
     }
 
@@ -46,5 +53,38 @@ public class CreateCommunityCommentService implements CreateCommunityCommentUseC
         if (communityCommentRepository.doesNotExistById(parentCommentId)) {
             throw new BadRequestException(NOT_EXISTS_COMMUNITY_COMMENT.getMessage());
         }
+    }
+
+    private void publishCommentAddedEvent(CommunityComment communityComment) {
+        Long parentCommentId = communityComment.getParentCommentId();
+
+        UUID targetVolunteerId = getTargetVolunteerId(communityComment, parentCommentId);
+
+        CommentAddedEvent event = CommentAddedEvent.builder()
+                .type(ServerEventType.NOTIFICATION)
+                .subType(NotificationSubType.COMMENT_ADDED)
+                .volunteerId(targetVolunteerId)
+                .communityBoardId(communityComment.getCommunityBoardId())
+                .build();
+
+        serverEventPublisher.publish(event);
+    }
+
+    private UUID getTargetVolunteerId(CommunityComment communityComment, Long parentCommentId) {
+        UUID targetVolunteerId;
+
+        if (parentCommentId == null) {
+            targetVolunteerId = communityBoardRepository.findById(communityComment.getCommunityBoardId())
+                    .orElseThrow(EntityNotFoundException::new)
+                    .getWriterId();
+
+            return targetVolunteerId;
+        }
+
+        targetVolunteerId = communityCommentRepository.findById(parentCommentId)
+                .map(CommunityComment::getWriterId)
+                .orElse(null);
+
+        return targetVolunteerId;
     }
 }

--- a/src/main/java/com/somemore/global/common/event/ServerEvent.java
+++ b/src/main/java/com/somemore/global/common/event/ServerEvent.java
@@ -24,8 +24,19 @@ public abstract class ServerEvent<T extends Enum<T>> {
             @JsonProperty(value = "subType", required = true) T subType,
             @JsonProperty(value = "createdAt", required = true) LocalDateTime createdAt
     ) {
+        validate(type, subType);
         this.type = type;
         this.subType = subType;
         this.createdAt = (createdAt == null) ? LocalDateTime.now() : createdAt;
+    }
+
+    private void validate(ServerEventType type, T subType) {
+        if (!type.getSubtype().isInstance(subType)) {
+            throw new IllegalArgumentException(String.format(
+                    "잘못된 서브타입: %s는 %s와 일치하지 않습니다.",
+                    subType,
+                    type.getSubtype()
+            ));
+        }
     }
 }

--- a/src/main/java/com/somemore/notification/converter/MessageConverter.java
+++ b/src/main/java/com/somemore/notification/converter/MessageConverter.java
@@ -1,9 +1,9 @@
 package com.somemore.notification.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.somemore.community.event.CommentAddedEvent;
 import com.somemore.facade.event.VolunteerReviewRequestEvent;
 import com.somemore.notification.domain.Notification;
 import com.somemore.notification.domain.NotificationSubType;
@@ -29,6 +29,7 @@ public class MessageConverter {
                 case NOTE_BLAH_BLAH -> throw new UnsupportedOperationException("NOTE 알림 타입 처리 로직 미구현");
                 case VOLUNTEER_REVIEW_REQUEST -> buildVolunteerReviewRequestNotification(message);
                 case VOLUNTEER_APPLY_STATUS_CHANGE -> buildVolunteerApplyStatusChangeNotification(message);
+                case COMMENT_ADDED -> buildCommentAddedNotification(message);
             };
         } catch (Exception e) {
             log.error(e.getMessage());
@@ -58,6 +59,17 @@ public class MessageConverter {
                 .build();
     }
 
+    private Notification buildCommentAddedNotification(String message) throws JsonProcessingException {
+        CommentAddedEvent event = objectMapper.readValue(message, CommentAddedEvent.class);
+
+        return Notification.builder()
+                .receiverId(event.getVolunteerId())
+                .title(createCommentAddedNotificationTitle())
+                .type(NotificationSubType.COMMENT_ADDED)
+                .relatedId(event.getCommunityBoardId())
+                .build();
+    }
+
     private String createVolunteerReviewRequestNotificationTitle() {
         return "최근 활동하신 활동의 후기를 작성해 주세요!";
     }
@@ -71,5 +83,9 @@ public class MessageConverter {
                 throw new IllegalArgumentException();
             }
         };
+    }
+
+    private String createCommentAddedNotificationTitle() {
+        return "새로운 댓글이 작성되었습니다.";
     }
 }

--- a/src/main/java/com/somemore/notification/domain/NotificationSubType.java
+++ b/src/main/java/com/somemore/notification/domain/NotificationSubType.java
@@ -8,7 +8,8 @@ import java.util.Arrays;
 public enum NotificationSubType {
     NOTE_BLAH_BLAH("쪽지"),
     VOLUNTEER_REVIEW_REQUEST("봉사 후기 요청"),
-    VOLUNTEER_APPLY_STATUS_CHANGE("신청 상태 변경")
+    VOLUNTEER_APPLY_STATUS_CHANGE("신청 상태 변경"),
+    COMMENT_ADDED("댓글 대댓글 추가")
     ;
 
     private final String description;

--- a/src/main/java/com/somemore/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/somemore/notification/dto/NotificationResponseDto.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Schema(description = "알림 응답 전송 DTO")
+@Schema(description = "알림 응답 DTO")
 public record NotificationResponseDto(
+        @Schema(description = "알림 ID", example = "1")
+        Long id,
         @Schema(description = "알림 제목", example = "봉사 활동 신청이 승인되었습니다.")
         String title,
 
@@ -25,6 +27,7 @@ public record NotificationResponseDto(
 
     public static NotificationResponseDto from(Notification notification) {
         return new NotificationResponseDto(
+                notification.getId(),
                 notification.getTitle(),
                 notification.getType(),
                 notification.getRelatedId(),


### PR DESCRIPTION
resolved : 
- #204 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
댓글 및 대댓글 작성 시 알림 기능을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 댓글 작성 시
- 커뮤니티 글 작성자에게 알림이 전송됩니다.
2. 대댓글 작성 시
- 부모 댓글 작성자에게 알림이 전송됩니다.
3. 전체 흐름
- 댓글/대댓글 작성 시, Redis로 이벤트를 발행.
- 이벤트를 구독하여 알림을 생성 및 저장.
- 알림은 SSE를 통해 클라이언트로 실시간 전송.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
프론트 요청으로 알림 아이디를 추가했습니다. (읽음 처리할 때 필요)