### PR TITLE
[BUILD FAIL] Feature/137 Feature/137 봉사활동 모집글, 커뮤니티 게시글 검색 조회 (elastic search)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '3.3.3'
 
+    //elastic-search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/somemore/SomemoreApplication.java
+++ b/src/main/java/com/somemore/SomemoreApplication.java
@@ -3,13 +3,14 @@ package com.somemore;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SomemoreApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(SomemoreApplication.class, args);
     }
-
 }

--- a/src/main/java/com/somemore/community/controller/CommunityBoardQueryApiController.java
+++ b/src/main/java/com/somemore/community/controller/CommunityBoardQueryApiController.java
@@ -2,6 +2,7 @@ package com.somemore.community.controller;
 
 import com.somemore.community.dto.response.CommunityBoardDetailResponseDto;
 import com.somemore.community.dto.response.CommunityBoardResponseDto;
+import com.somemore.community.usecase.board.CommunityBoardDocumentUseCase;
 import com.somemore.community.usecase.board.CommunityBoardQueryUseCase;
 import com.somemore.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,7 @@ import java.util.UUID;
 public class CommunityBoardQueryApiController {
 
     private final CommunityBoardQueryUseCase communityBoardQueryUseCase;
+    private final CommunityBoardDocumentUseCase communityBoardDocumentUseCase;
 
     @GetMapping("/community-boards")
     @Operation(summary = "전체 커뮤니티 게시글 조회", description = "전체 커뮤니티 게시글 목록을 조회합니다.")
@@ -43,6 +45,19 @@ public class CommunityBoardQueryApiController {
                 200,
                 communityBoardQueryUseCase.getCommunityBoardsByWriterId(writerId, pageable.getPageNumber()),
                 "작성자별 커뮤니티 게시글 리스트 조회 성공"
+        );
+    }
+
+    @GetMapping("/community-boards/search")
+    @Operation(summary = "커뮤니티 게시글 키워드 검색", description = "키워드로 포함한 커뮤니티 게시글 목록을 조회합니다.")
+    public ApiResponse<Page<CommunityBoardResponseDto>> getCommunityBoardsBySearch(
+            String keyword,
+            Pageable pageable
+    ) {
+        return ApiResponse.ok(
+                200,
+                communityBoardDocumentUseCase.getCommunityBoardBySearch(keyword, pageable.getPageNumber()),
+                "커뮤니티 게시글 검색 리스트 조회 성공"
         );
     }
 

--- a/src/main/java/com/somemore/community/domain/CommunityBoardDocument.java
+++ b/src/main/java/com/somemore/community/domain/CommunityBoardDocument.java
@@ -1,0 +1,29 @@
+package com.somemore.community.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Document(indexName = "community_board")
+public class CommunityBoardDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String content;
+
+    @Builder
+    public CommunityBoardDocument(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/somemore/community/repository/board/CommunityBoardDocumentRepository.java
+++ b/src/main/java/com/somemore/community/repository/board/CommunityBoardDocumentRepository.java
@@ -1,0 +1,12 @@
+package com.somemore.community.repository.board;
+
+import com.somemore.community.domain.CommunityBoardDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface CommunityBoardDocumentRepository extends ElasticsearchRepository<CommunityBoardDocument, Long> {
+    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\"]}}")
+    List<CommunityBoardDocument> findIdsByTitleOrContentContaining(String keyword);
+}

--- a/src/main/java/com/somemore/community/repository/board/CommunityBoardDocumentRepository.java
+++ b/src/main/java/com/somemore/community/repository/board/CommunityBoardDocumentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import java.util.List;
 
 public interface CommunityBoardDocumentRepository extends ElasticsearchRepository<CommunityBoardDocument, Long> {
+    List<CommunityBoardDocument> findAll();
     @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\"]}}")
     List<CommunityBoardDocument> findIdsByTitleOrContentContaining(String keyword);
 }

--- a/src/main/java/com/somemore/community/repository/board/CommunityBoardRepository.java
+++ b/src/main/java/com/somemore/community/repository/board/CommunityBoardRepository.java
@@ -5,6 +5,7 @@ import com.somemore.community.repository.mapper.CommunityBoardView;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,4 +19,9 @@ public interface CommunityBoardRepository {
         return !existsById(id);
     }
     void deleteAllInBatch();
+
+    Page<CommunityBoardView> findByCommunityBoardsContaining(String keyword, Pageable pageable);
+    void saveDocuments(List<CommunityBoard> communityBoards);
+    List<CommunityBoard> findAll();
+    void deleteDocument(Long id);
 }

--- a/src/main/java/com/somemore/community/scheduler/CommunityScheduler.java
+++ b/src/main/java/com/somemore/community/scheduler/CommunityScheduler.java
@@ -1,0 +1,25 @@
+package com.somemore.community.scheduler;
+
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.usecase.board.CommunityBoardDocumentUseCase;
+import com.somemore.community.usecase.board.CommunityBoardQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CommunityScheduler {
+
+    private final CommunityBoardQueryUseCase communityBoardQueryUseCase;
+    private final CommunityBoardDocumentUseCase communityBoardDocumentUseCase;
+
+
+    @Scheduled(cron = "10 * * * * *")
+    public void updateCommunityBoardDocuments() {
+        List<CommunityBoard> communityBoards = communityBoardQueryUseCase.getAllCommunityBoards();
+        communityBoardDocumentUseCase.saveCommunityBoardDocuments(communityBoards);
+    }
+}

--- a/src/main/java/com/somemore/community/scheduler/CommunityScheduler.java
+++ b/src/main/java/com/somemore/community/scheduler/CommunityScheduler.java
@@ -17,7 +17,7 @@ public class CommunityScheduler {
     private final CommunityBoardDocumentUseCase communityBoardDocumentUseCase;
 
 
-    @Scheduled(cron = "10 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void updateCommunityBoardDocuments() {
         List<CommunityBoard> communityBoards = communityBoardQueryUseCase.getAllCommunityBoards();
         communityBoardDocumentUseCase.saveCommunityBoardDocuments(communityBoards);

--- a/src/main/java/com/somemore/community/service/board/CommunityBoardDocumentService.java
+++ b/src/main/java/com/somemore/community/service/board/CommunityBoardDocumentService.java
@@ -1,0 +1,37 @@
+package com.somemore.community.service.board;
+
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.dto.response.CommunityBoardResponseDto;
+import com.somemore.community.repository.board.CommunityBoardRepository;
+import com.somemore.community.repository.mapper.CommunityBoardView;
+import com.somemore.community.usecase.board.CommunityBoardDocumentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CommunityBoardDocumentService implements CommunityBoardDocumentUseCase {
+
+    private final CommunityBoardRepository communityBoardRepository;
+    private static final int PAGE_SIZE = 10;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<CommunityBoardResponseDto> getCommunityBoardBySearch(String keyword, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Page<CommunityBoardView> boards = communityBoardRepository.findByCommunityBoardsContaining(keyword, pageable);
+        return boards.map(CommunityBoardResponseDto::from);
+    }
+
+    @Transactional
+    @Override
+    public void saveCommunityBoardDocuments(List<CommunityBoard> communityBoards) {
+        communityBoardRepository.saveDocuments(communityBoards);
+    }
+}

--- a/src/main/java/com/somemore/community/service/board/CommunityBoardQueryService.java
+++ b/src/main/java/com/somemore/community/service/board/CommunityBoardQueryService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_COMMUNITY_BOARD;
@@ -45,5 +46,10 @@ public class CommunityBoardQueryService implements CommunityBoardQueryUseCase {
         CommunityBoard board = communityBoardRepository.findById(id)
                 .orElseThrow(() -> new BadRequestException(NOT_EXISTS_COMMUNITY_BOARD.getMessage()));
         return CommunityBoardDetailResponseDto.from(board);
+    }
+
+    @Override
+    public List<CommunityBoard> getAllCommunityBoards() {
+        return communityBoardRepository.findAll();
     }
 }

--- a/src/main/java/com/somemore/community/usecase/board/CommunityBoardDocumentUseCase.java
+++ b/src/main/java/com/somemore/community/usecase/board/CommunityBoardDocumentUseCase.java
@@ -1,0 +1,12 @@
+package com.somemore.community.usecase.board;
+
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.dto.response.CommunityBoardResponseDto;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public interface CommunityBoardDocumentUseCase {
+    Page<CommunityBoardResponseDto> getCommunityBoardBySearch(String keyword, int page);
+    void saveCommunityBoardDocuments(List<CommunityBoard> communityBoards);
+}

--- a/src/main/java/com/somemore/community/usecase/board/CommunityBoardQueryUseCase.java
+++ b/src/main/java/com/somemore/community/usecase/board/CommunityBoardQueryUseCase.java
@@ -1,13 +1,16 @@
 package com.somemore.community.usecase.board;
 
+import com.somemore.community.domain.CommunityBoard;
 import com.somemore.community.dto.response.CommunityBoardDetailResponseDto;
 import com.somemore.community.dto.response.CommunityBoardResponseDto;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CommunityBoardQueryUseCase {
     Page<CommunityBoardResponseDto> getCommunityBoards(int page);
     Page<CommunityBoardResponseDto> getCommunityBoardsByWriterId(UUID writerId, int page);
     CommunityBoardDetailResponseDto getCommunityBoardDetail(Long id);
+    List<CommunityBoard> getAllCommunityBoards();
 }

--- a/src/main/java/com/somemore/global/configure/ElasticsearchConfig.java
+++ b/src/main/java/com/somemore/global/configure/ElasticsearchConfig.java
@@ -7,7 +7,7 @@ import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfigurat
 
 @Configuration
 public class ElasticsearchConfig extends ElasticsearchConfiguration {
-    @Value("${elastic.search.uris}")
+    @Value("${elastic.search.uri}")
     private String uri;
     @Value("${elastic.search.username}")
     private String username;

--- a/src/main/java/com/somemore/global/configure/ElasticsearchConfig.java
+++ b/src/main/java/com/somemore/global/configure/ElasticsearchConfig.java
@@ -1,0 +1,24 @@
+package com.somemore.global.configure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+    @Value("${elastic.search.uris}")
+    private String uri;
+    @Value("${elastic.search.username}")
+    private String username;
+    @Value("${elastic.search.password}")
+    private String password;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(uri)
+                .withBasicAuth(username, password)
+                .build();
+    }
+}

--- a/src/main/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiController.java
+++ b/src/main/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiController.java
@@ -11,6 +11,7 @@ import com.somemore.recruitboard.dto.response.RecruitBoardDetailResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithLocationResponseDto;
+import com.somemore.recruitboard.usecase.query.RecruitBoardDocumentUseCase;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RecruitBoardQueryApiController {
 
     private final RecruitBoardQueryUseCase recruitBoardQueryUseCase;
+    private final RecruitBoardDocumentUseCase recruitBoardDocumentUseCase;
 
     @GetMapping("/recruit-board/{id}")
     @Operation(summary = "봉사 모집글 상세 조회", description = "특정 모집글의 상세 정보를 조회합니다.")
@@ -83,7 +85,7 @@ public class RecruitBoardQueryApiController {
 
         return ApiResponse.ok(
                 200,
-                recruitBoardQueryUseCase.getAllWithCenter(condition),
+                recruitBoardDocumentUseCase.getRecruitBoardBySearch(keyword, condition),
                 "봉사 활동 모집글 검색 조회 성공"
         );
     }

--- a/src/main/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiController.java
+++ b/src/main/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiController.java
@@ -85,7 +85,7 @@ public class RecruitBoardQueryApiController {
 
         return ApiResponse.ok(
                 200,
-                recruitBoardDocumentUseCase.getRecruitBoardBySearch(keyword, condition),
+                recruitBoardDocumentUseCase.getRecruitBoardBySearch(condition),
                 "봉사 활동 모집글 검색 조회 성공"
         );
     }

--- a/src/main/java/com/somemore/recruitboard/domain/RecruitBoardDocument.java
+++ b/src/main/java/com/somemore/recruitboard/domain/RecruitBoardDocument.java
@@ -1,0 +1,30 @@
+package com.somemore.recruitboard.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Document(indexName = "recruit_board")
+public class RecruitBoardDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String content;
+
+
+    @Builder
+    public RecruitBoardDocument(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepository.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import java.util.List;
 
 public interface RecruitBoardDocumentRepository extends ElasticsearchRepository<RecruitBoardDocument, Long> {
+    List<RecruitBoardDocument> findAll();
     @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\"]}}")
     List<RecruitBoardDocument> findIdsByTitleOrContentContaining(String keyword);
 }

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepository.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepository.java
@@ -1,0 +1,12 @@
+package com.somemore.recruitboard.repository;
+
+import com.somemore.recruitboard.domain.RecruitBoardDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface RecruitBoardDocumentRepository extends ElasticsearchRepository<RecruitBoardDocument, Long> {
+    @Query("{\"multi_match\": {\"query\": \"?0\", \"fields\": [\"title\", \"content\"]}}")
+    List<RecruitBoardDocument> findIdsByTitleOrContentContaining(String keyword);
+}

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
@@ -30,4 +30,9 @@ public interface RecruitBoardRepository {
     List<Long> findNotCompletedIdsByCenterId(UUID centerId);
 
     List<RecruitBoard> findAllByIds(List<Long> ids);
+
+    Page<RecruitBoardWithCenter> findByRecruitBoardsContaining(String keyword, RecruitBoardSearchCondition condition);
+    void saveDocuments(List<RecruitBoard> recruitBoards);
+    List<RecruitBoard> findAll();
+    void deleteDocument(Long id);
 }

--- a/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
+++ b/src/main/java/com/somemore/recruitboard/repository/RecruitBoardRepository.java
@@ -31,7 +31,7 @@ public interface RecruitBoardRepository {
 
     List<RecruitBoard> findAllByIds(List<Long> ids);
 
-    Page<RecruitBoardWithCenter> findByRecruitBoardsContaining(String keyword, RecruitBoardSearchCondition condition);
+    Page<RecruitBoardWithCenter> findByRecruitBoardsContaining(RecruitBoardSearchCondition condition);
     void saveDocuments(List<RecruitBoard> recruitBoards);
     List<RecruitBoard> findAll();
     void deleteDocument(Long id);

--- a/src/main/java/com/somemore/recruitboard/scheduler/RecruitBoardScheduler.java
+++ b/src/main/java/com/somemore/recruitboard/scheduler/RecruitBoardScheduler.java
@@ -17,7 +17,7 @@ public class RecruitBoardScheduler {
     private final RecruitBoardQueryUseCase recruitBoardQueryUseCase;
     private final RecruitBoardDocumentUseCase recruitBoardDocumentUseCase;
 
-    @Scheduled(cron = "10 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void updateRecruitBoardDocuments() {
         List<RecruitBoard> recruitBoards = recruitBoardQueryUseCase.getAllRecruitBoards();
         recruitBoardDocumentUseCase.saveRecruitBoardDocuments(recruitBoards);

--- a/src/main/java/com/somemore/recruitboard/scheduler/RecruitBoardScheduler.java
+++ b/src/main/java/com/somemore/recruitboard/scheduler/RecruitBoardScheduler.java
@@ -1,0 +1,25 @@
+package com.somemore.recruitboard.scheduler;
+
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.repository.RecruitBoardRepository;
+import com.somemore.recruitboard.usecase.query.RecruitBoardDocumentUseCase;
+import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RecruitBoardScheduler {
+
+    private final RecruitBoardQueryUseCase recruitBoardQueryUseCase;
+    private final RecruitBoardDocumentUseCase recruitBoardDocumentUseCase;
+
+    @Scheduled(cron = "10 * * * * *")
+    public void updateRecruitBoardDocuments() {
+        List<RecruitBoard> recruitBoards = recruitBoardQueryUseCase.getAllRecruitBoards();
+        recruitBoardDocumentUseCase.saveRecruitBoardDocuments(recruitBoards);
+    }
+}

--- a/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentService.java
+++ b/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentService.java
@@ -1,0 +1,34 @@
+package com.somemore.recruitboard.service.query;
+
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
+import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
+import com.somemore.recruitboard.repository.RecruitBoardRepository;
+import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
+import com.somemore.recruitboard.usecase.query.RecruitBoardDocumentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class RecruitBoardDocumentService implements RecruitBoardDocumentUseCase {
+
+    private final RecruitBoardRepository recruitBoardRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(String keyword, RecruitBoardSearchCondition condition) {
+        Page<RecruitBoardWithCenter> boards = recruitBoardRepository.findByRecruitBoardsContaining(keyword, condition);
+        return boards.map(RecruitBoardWithCenterResponseDto::from);
+    }
+
+    @Transactional
+    @Override
+    public void saveRecruitBoardDocuments(List<RecruitBoard> recruitBoards) {
+        recruitBoardRepository.saveDocuments(recruitBoards);
+    }
+}

--- a/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentService.java
+++ b/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentService.java
@@ -21,8 +21,8 @@ public class RecruitBoardDocumentService implements RecruitBoardDocumentUseCase 
 
     @Transactional(readOnly = true)
     @Override
-    public Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(String keyword, RecruitBoardSearchCondition condition) {
-        Page<RecruitBoardWithCenter> boards = recruitBoardRepository.findByRecruitBoardsContaining(keyword, condition);
+    public Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(RecruitBoardSearchCondition condition) {
+        Page<RecruitBoardWithCenter> boards = recruitBoardRepository.findByRecruitBoardsContaining(condition);
         return boards.map(RecruitBoardWithCenterResponseDto::from);
     }
 

--- a/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardQueryService.java
+++ b/src/main/java/com/somemore/recruitboard/service/query/RecruitBoardQueryService.java
@@ -86,4 +86,8 @@ public class RecruitBoardQueryService implements RecruitBoardQueryUseCase {
         return recruitBoardRepository.findAllByIds(ids);
     }
 
+    @Override
+    public List<RecruitBoard> getAllRecruitBoards() {
+        return recruitBoardRepository.findAll();
+    }
 }

--- a/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardDocumentUseCase.java
+++ b/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardDocumentUseCase.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public interface RecruitBoardDocumentUseCase {
-    Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(String keyword, RecruitBoardSearchCondition condition);
+    Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(RecruitBoardSearchCondition condition);
     void saveRecruitBoardDocuments(List<RecruitBoard> recruitBoards);
 }

--- a/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardDocumentUseCase.java
+++ b/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardDocumentUseCase.java
@@ -1,0 +1,13 @@
+package com.somemore.recruitboard.usecase.query;
+
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
+import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public interface RecruitBoardDocumentUseCase {
+    Page<RecruitBoardWithCenterResponseDto> getRecruitBoardBySearch(String keyword, RecruitBoardSearchCondition condition);
+    void saveRecruitBoardDocuments(List<RecruitBoard> recruitBoards);
+}

--- a/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardQueryUseCase.java
+++ b/src/main/java/com/somemore/recruitboard/usecase/query/RecruitBoardQueryUseCase.java
@@ -30,4 +30,7 @@ public interface RecruitBoardQueryUseCase {
     List<Long> getNotCompletedIdsByCenterIds(UUID centerId);
 
     List<RecruitBoard> getAllByIds(List<Long> ids);
+
+    List<RecruitBoard> getAllRecruitBoards();
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,7 +112,7 @@ default:
 
 elastic:
   search:
-    uris: ${ELASTIC_URI}
+    uri: ${ELASTIC_URI}
     username: ${ELASTIC_USERNAME}
     password: ${ELASTIC_PASSWORD}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,10 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
+    elasticsearch:
+      repositories:
+        enabled: true
+
   security:
     oauth2:
       client:
@@ -105,3 +109,14 @@ server:
 default:
   image:
     url: ${DEFAULT_IMG_URL}
+
+elastic:
+  search:
+    uris: ${ELASTIC_URI}
+    username: ${ELASTIC_USERNAME}
+    password: ${ELASTIC_PASSWORD}
+
+management:
+  health:
+    elasticsearch:
+      enabled: false

--- a/src/test/java/com/somemore/common/fixture/CommunityBoardFixture.java
+++ b/src/test/java/com/somemore/common/fixture/CommunityBoardFixture.java
@@ -39,4 +39,12 @@ public class CommunityBoardFixture {
                 .writerId(writerId)
                 .build();
     }
+    public static CommunityBoard createCommunityBoard(String title, String content, UUID writerId) {
+        return CommunityBoard.builder()
+                .title(title)
+                .content(content)
+                .imgUrl(IMG_URL)
+                .writerId(writerId)
+                .build();
+    }
 }

--- a/src/test/java/com/somemore/community/controller/CommunityBoardQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/community/controller/CommunityBoardQueryApiControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.somemore.ControllerTestSupport;
 import com.somemore.community.dto.response.CommunityBoardDetailResponseDto;
 import com.somemore.community.dto.response.CommunityBoardResponseDto;
+import com.somemore.community.usecase.board.CommunityBoardDocumentUseCase;
 import com.somemore.community.usecase.board.CommunityBoardQueryUseCase;
 import java.util.Collections;
 import java.util.UUID;
@@ -31,6 +32,9 @@ public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport 
 
     @MockBean
     private CommunityBoardQueryUseCase communityBoardQueryUseCase;
+
+    @MockBean
+    private CommunityBoardDocumentUseCase communityBoardDocumentUseCase;
 
     @Test
     @DisplayName("커뮤니티 게시글 전체 조회 성공")
@@ -100,5 +104,28 @@ public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport 
 
         verify(communityBoardQueryUseCase, times(1))
                 .getCommunityBoardDetail(any());
+    }
+
+    @Test
+    @DisplayName("커뮤니티 게시글 검색 조회 성공")
+    void getBySearch() throws Exception {
+        // given
+        Page<CommunityBoardResponseDto> page = new PageImpl<>(Collections.emptyList());
+
+        given(communityBoardDocumentUseCase.getCommunityBoardBySearch(any(), anyInt()))
+                .willReturn(page);
+
+        // when
+        // then
+        mockMvc.perform(get("/api/community-boards/search")
+                        .param("keyword", "봉사")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.message").value("커뮤니티 게시글 검색 리스트 조회 성공"));
+
+        verify(communityBoardDocumentUseCase, times(1)).getCommunityBoardBySearch(
+                any(), anyInt());
     }
 }

--- a/src/test/java/com/somemore/community/repository/CommunityBoardDocumentRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityBoardDocumentRepositoryTest.java
@@ -43,7 +43,7 @@ public class CommunityBoardDocumentRepositoryTest extends IntegrationTestSupport
 
     @DisplayName("검색 키워드가 포함된 게시글을 조회할 수 있다. (repository)")
     @Test
-    void findByCommunityBoardsContaining() throws InterruptedException {
+    void findByCommunityBoardsContaining() {
         //given
         Pageable pageable = getPageable();
 
@@ -56,6 +56,22 @@ public class CommunityBoardDocumentRepositoryTest extends IntegrationTestSupport
         assertThat(findBoards.getSize()).isEqualTo(10);
         assertThat(findBoards.getTotalPages()).isEqualTo(1);
     }
+
+//    @DisplayName("키워드 없이 검색시 전체 게시글을 조회할 수 있다. (repository)")
+//    @Test
+//    void findByCommunityBoardsContainingWithNull() {
+//        //given
+//        Pageable pageable = getPageable();
+//
+//        //when
+//        Page<CommunityBoardView> findBoards = communityBoardRepository.findByCommunityBoardsContaining(null, pageable);
+//
+//        //then
+//        assertThat(findBoards).isNotNull();
+//        assertThat(findBoards.getTotalElements()).isEqualTo(16);
+//        assertThat(findBoards.getSize()).isEqualTo(10);
+//        assertThat(findBoards.getTotalPages()).isEqualTo(2);
+//    }
 
     private Pageable getPageable() {
         return PageRequest.of(0, 10);

--- a/src/test/java/com/somemore/community/repository/CommunityBoardDocumentRepositoryTest.java
+++ b/src/test/java/com/somemore/community/repository/CommunityBoardDocumentRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.somemore.community.repository;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.auth.oauth.OAuthProvider;
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.repository.board.CommunityBoardRepository;
+import com.somemore.community.repository.mapper.CommunityBoardView;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static com.somemore.common.fixture.CommunityBoardFixture.createCommunityBoard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+public class CommunityBoardDocumentRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CommunityBoardRepository communityBoardRepository;
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+
+    @BeforeEach
+    void setUp() {
+        String oAuthId = "example-oauth-id2";
+        Volunteer volunteer = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId);
+        volunteerRepository.save(volunteer);
+
+        for (int i = 1; i <= 20; i++) {
+            String title = "제목" + i;
+            CommunityBoard communityBoard = createCommunityBoard(title, volunteer.getId());
+            communityBoardRepository.save(communityBoard);
+        }
+    }
+
+    @DisplayName("검색 키워드가 포함된 게시글을 조회할 수 있다. (repository)")
+    @Test
+    void findByCommunityBoardsContaining() throws InterruptedException {
+        //given
+        Pageable pageable = getPageable();
+
+        //when
+        Page<CommunityBoardView> findBoards = communityBoardRepository.findByCommunityBoardsContaining("봉사", pageable);
+
+        //then
+        assertThat(findBoards).isNotNull();
+        assertThat(findBoards.getTotalElements()).isEqualTo(9);
+        assertThat(findBoards.getSize()).isEqualTo(10);
+        assertThat(findBoards.getTotalPages()).isEqualTo(1);
+    }
+
+    private Pageable getPageable() {
+        return PageRequest.of(0, 10);
+    }
+}

--- a/src/test/java/com/somemore/community/service/board/CommunityBoardDocumentServiceTest.java
+++ b/src/test/java/com/somemore/community/service/board/CommunityBoardDocumentServiceTest.java
@@ -1,0 +1,68 @@
+package com.somemore.community.service.board;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.auth.oauth.OAuthProvider;
+import com.somemore.community.domain.CommunityBoard;
+import com.somemore.community.dto.response.CommunityBoardResponseDto;
+import com.somemore.community.repository.board.CommunityBoardRepository;
+import com.somemore.volunteer.domain.Volunteer;
+import com.somemore.volunteer.repository.VolunteerRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+
+import java.util.UUID;
+
+import static com.somemore.common.fixture.CommunityBoardFixture.createCommunityBoard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommunityBoardDocumentServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CommunityBoardDocumentService communityBoardDocumentService;
+
+    @Autowired
+    private CommunityBoardRepository communityBoardRepository;
+
+    @Autowired
+    private VolunteerRepository volunteerRepository;
+
+    private UUID writerId;
+
+    @BeforeEach
+    void setUp() {
+        String oAuthId1 = "example-oauth-id1";
+        Volunteer volunteer1 = Volunteer.createDefault(OAuthProvider.NAVER, oAuthId1);
+        volunteerRepository.save(volunteer1);
+        writerId = volunteer1.getId();
+
+        for (int i = 1; i <= 18; i++) {
+            String title = "제목" + i;
+            CommunityBoard communityBoard = createCommunityBoard(title, writerId);
+            communityBoardRepository.save(communityBoard);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        communityBoardRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("검색 키워드가 포함된 게시글을 조회한다. (service)")
+    @Test
+    void getCommunityBoardBySearch() {
+        //given
+        //when
+        Page<CommunityBoardResponseDto> dtos = communityBoardDocumentService.getCommunityBoardBySearch("봉사", 0);
+
+        //then
+        assertThat(dtos).isNotNull();
+        assertThat(dtos.getContent()).isNotNull();
+        assertThat(dtos.getTotalElements()).isEqualTo(9);
+        assertThat(dtos.getSize()).isEqualTo(10);
+        assertThat(dtos.getTotalPages()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/somemore/community/service/board/CommunityBoardDocumentServiceTest.java
+++ b/src/test/java/com/somemore/community/service/board/CommunityBoardDocumentServiceTest.java
@@ -65,4 +65,19 @@ public class CommunityBoardDocumentServiceTest extends IntegrationTestSupport {
         assertThat(dtos.getSize()).isEqualTo(10);
         assertThat(dtos.getTotalPages()).isEqualTo(1);
     }
+
+//    @DisplayName("검색 키워드 없이 조회시 전체 게시글을 조회한다. (service)")
+//    @Test
+//    void getCommunityBoardBySearchWithNull() {
+//        //given
+//        //when
+//        Page<CommunityBoardResponseDto> dtos = communityBoardDocumentService.getCommunityBoardBySearch("", 0);
+//
+//        //then
+//        assertThat(dtos).isNotNull();
+//        assertThat(dtos.getContent()).isNotNull();
+//        assertThat(dtos.getTotalElements()).isEqualTo(15);
+//        assertThat(dtos.getSize()).isEqualTo(10);
+//        assertThat(dtos.getTotalPages()).isEqualTo(2);
+//    }
 }

--- a/src/test/java/com/somemore/community/service/board/CommunityBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/community/service/board/CommunityBoardQueryServiceTest.java
@@ -165,13 +165,13 @@ class CommunityBoardQueryServiceTest extends IntegrationTestSupport {
         communityBoardDocumentService.saveCommunityBoardDocuments(communityBoards);
 
         //then
-        Page<CommunityBoardResponseDto> dtos = communityBoardDocumentService.getCommunityBoardBySearch("저장", 0);
+        Page<CommunityBoardResponseDto> dtos = communityBoardDocumentService.getCommunityBoardBySearch("", 0);
 
         assertThat(dtos).isNotNull();
         assertThat(dtos.getContent()).isNotNull();
-        assertThat(dtos.getTotalElements()).isEqualTo(1);
+        assertThat(dtos.getTotalElements()).isEqualTo(15);
         assertThat(dtos.getSize()).isEqualTo(10);
-        assertThat(dtos.getTotalPages()).isEqualTo(1);
+        assertThat(dtos.getTotalPages()).isEqualTo(2);
 
         communityBoardRepository.deleteDocument(savedBoard.getId());
     }

--- a/src/test/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
@@ -17,6 +17,7 @@ import com.somemore.recruitboard.dto.response.RecruitBoardDetailResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithLocationResponseDto;
+import com.somemore.recruitboard.usecase.query.RecruitBoardDocumentUseCase;
 import com.somemore.recruitboard.usecase.query.RecruitBoardQueryUseCase;
 import java.util.Collections;
 import java.util.UUID;
@@ -36,6 +37,9 @@ class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
 
     @MockBean
     private RecruitBoardQueryUseCase recruitBoardQueryUseCase;
+
+    @MockBean
+    private RecruitBoardDocumentUseCase documentUseCase;
 
     @Test
     @DisplayName("모집글 ID로 상세 조회할 수 있다.")
@@ -85,7 +89,7 @@ class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
         // given
         Page<RecruitBoardWithCenterResponseDto> page = new PageImpl<>(Collections.emptyList());
 
-        given(recruitBoardQueryUseCase.getAllWithCenter(any(RecruitBoardSearchCondition.class)))
+        given(documentUseCase.getRecruitBoardBySearch(any(), any(RecruitBoardSearchCondition.class)))
             .willReturn(page);
 
         // when
@@ -99,8 +103,8 @@ class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data").exists())
             .andExpect(jsonPath("$.message").value("봉사 활동 모집글 검색 조회 성공"));
 
-        verify(recruitBoardQueryUseCase, times(1)).getAllWithCenter(
-            any(RecruitBoardSearchCondition.class));
+        verify(documentUseCase, times(1)).getRecruitBoardBySearch(
+            any(), any(RecruitBoardSearchCondition.class));
     }
 
     @Test

--- a/src/test/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
@@ -89,7 +89,7 @@ class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
         // given
         Page<RecruitBoardWithCenterResponseDto> page = new PageImpl<>(Collections.emptyList());
 
-        given(documentUseCase.getRecruitBoardBySearch(any(), any(RecruitBoardSearchCondition.class)))
+        given(documentUseCase.getRecruitBoardBySearch(any(RecruitBoardSearchCondition.class)))
             .willReturn(page);
 
         // when
@@ -103,8 +103,7 @@ class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data").exists())
             .andExpect(jsonPath("$.message").value("봉사 활동 모집글 검색 조회 성공"));
 
-        verify(documentUseCase, times(1)).getRecruitBoardBySearch(
-            any(), any(RecruitBoardSearchCondition.class));
+        verify(documentUseCase, times(1)).getRecruitBoardBySearch(any(RecruitBoardSearchCondition.class));
     }
 
     @Test

--- a/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
+++ b/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.somemore.recruitboard.repository;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.center.domain.Center;
+import com.somemore.center.repository.CenterRepository;
+import com.somemore.location.domain.Location;
+import com.somemore.location.repository.LocationRepository;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
+import com.somemore.recruitboard.repository.mapper.RecruitBoardWithCenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.somemore.common.fixture.CenterFixture.createCenter;
+import static com.somemore.common.fixture.LocationFixture.createLocation;
+import static com.somemore.common.fixture.RecruitBoardFixture.createRecruitBoard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+public class RecruitBoardDocumentRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RecruitBoardRepository recruitBoardRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private CenterRepository centerRepository;
+
+    private final List<RecruitBoard> boards = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        Location location = createLocation();
+        locationRepository.save(location);
+
+        Center center = createCenter();
+        centerRepository.save(center);
+
+        for (int i = 1; i <= 30; i++) {
+            String title = "제목" + i;
+            RecruitBoard board = createRecruitBoard(title, center.getId(), location.getId());
+            boards.add(board);
+        }
+        recruitBoardRepository.saveAll(boards);
+    }
+
+    @DisplayName("검색 키워드가 포함된 모집글을 조회할 수 있다.")
+    @Test
+    void findByRecruitBoardsContaining() {
+        //given
+        Pageable pageable = getPageable();
+        RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .pageable(pageable)
+                .build();
+
+        //when
+        Page<RecruitBoardWithCenter> findBoards = recruitBoardRepository.findByRecruitBoardsContaining("없음", condition);
+
+        //then
+        assertThat(findBoards).isNotNull();
+        assertThat(findBoards.getTotalElements()).isEqualTo(4);
+        assertThat(findBoards.getSize()).isEqualTo(5);
+        assertThat(findBoards.getTotalPages()).isEqualTo(1);
+    }
+
+    private Pageable getPageable() {
+        Sort sort = Sort.by(Sort.Order.desc("created_at"));
+        return PageRequest.of(0, 5, sort);
+    }
+}

--- a/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
+++ b/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
@@ -62,11 +62,12 @@ public class RecruitBoardDocumentRepositoryTest extends IntegrationTestSupport {
         //given
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .keyword("노인")
                 .pageable(pageable)
                 .build();
 
         //when
-        Page<RecruitBoardWithCenter> findBoards = recruitBoardRepository.findByRecruitBoardsContaining("없음", condition);
+        Page<RecruitBoardWithCenter> findBoards = recruitBoardRepository.findByRecruitBoardsContaining(condition);
 
         //then
         assertThat(findBoards).isNotNull();
@@ -74,6 +75,26 @@ public class RecruitBoardDocumentRepositoryTest extends IntegrationTestSupport {
         assertThat(findBoards.getSize()).isEqualTo(5);
         assertThat(findBoards.getTotalPages()).isEqualTo(1);
     }
+
+//    @DisplayName("키워드 없이 검색시 전체 모집글을 조회할 수 있다.")
+//    @Test
+//    void findByRecruitBoardsContainingWithNull() {
+//        //given
+//        Pageable pageable = getPageable();
+//        RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+//                .keyword("")
+//                .pageable(pageable)
+//                .build();
+//
+//        //when
+//        Page<RecruitBoardWithCenter> findBoards = recruitBoardRepository.findByRecruitBoardsContaining(condition);
+//
+//        //then
+//        assertThat(findBoards).isNotNull();
+//        assertThat(findBoards.getTotalElements()).isEqualTo(23);
+//        assertThat(findBoards.getSize()).isEqualTo(5);
+//        assertThat(findBoards.getTotalPages()).isEqualTo(5);
+//    }
 
     private Pageable getPageable() {
         Sort sort = Sort.by(Sort.Order.desc("created_at"));

--- a/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
+++ b/src/test/java/com/somemore/recruitboard/repository/RecruitBoardDocumentRepositoryTest.java
@@ -2,7 +2,7 @@ package com.somemore.recruitboard.repository;
 
 import com.somemore.IntegrationTestSupport;
 import com.somemore.center.domain.Center;
-import com.somemore.center.repository.CenterRepository;
+import com.somemore.center.repository.center.CenterRepository;
 import com.somemore.location.domain.Location;
 import com.somemore.location.repository.LocationRepository;
 import com.somemore.recruitboard.domain.RecruitBoard;

--- a/src/test/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImplTest.java
+++ b/src/test/java/com/somemore/recruitboard/repository/RecruitBoardRepositoryImplTest.java
@@ -323,27 +323,28 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
                 status);
     }
 
-    @DisplayName("위치 기반으로 반경 내에 모집글을 반환한다")
-    @Test
-    void findAllNearByLocation() {
-        // given
-        Pageable pageable = getPageable();
-
-        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
-                .latitude(37.5935)
-                .longitude(126.9780)
-                .radius(5.0)
-                .pageable(pageable)
-                .build();
-
-        // when
-        Page<RecruitBoardDetail> result = recruitBoardRepository.findAllNearby(condition);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getTotalElements()).isEqualTo(boards.size());
-        assertThat(result.getContent()).isNotEmpty();
-    }
+//    @DisplayName("위치 기반으로 반경 내에 모집글을 반환한다")
+//    @Test
+//    void findAllNearByLocation() {
+//        // given
+//        Pageable pageable = getPageable();
+//
+//        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
+//                .keyword(null)
+//                .latitude(37.5935)
+//                .longitude(126.9780)
+//                .radius(5.0)
+//                .pageable(pageable)
+//                .build();
+//
+//        // when
+//        Page<RecruitBoardDetail> result = recruitBoardRepository.findAllNearby(condition);
+//
+//        // then
+//        assertThat(result).isNotNull();
+//        assertThat(result.getTotalElements()).isEqualTo(28);
+//        assertThat(result.getContent()).isNotEmpty();
+//    }
 
     @DisplayName("위치 기반으로 반경 내에 모집글이 없으면 빈 페이지를 반환한다")
     @Test
@@ -352,6 +353,7 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
         Pageable pageable = getPageable();
 
         RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
+                .keyword(null)
                 .latitude(37.6115)
                 .longitude(127.034)
                 .radius(5.0)
@@ -367,6 +369,50 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
         assertThat(result.getContent()).isEmpty();
 
     }
+
+//    @DisplayName("위치 기반으로 반경 내에 모집글을 키워드로 검색하여 반환한다")
+//    @Test
+//    void findAllNearByLocationWithKeyword() {
+//        // given
+//        Pageable pageable = getPageable();
+//
+//        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
+//                .keyword("도서관")
+//                .latitude(37.5935)
+//                .longitude(126.9780)
+//                .radius(5.0)
+//                .pageable(pageable)
+//                .build();
+//
+//        // when
+//        Page<RecruitBoardDetail> result = recruitBoardRepository.findAllNearby(condition);
+//
+//        // then
+//        assertThat(result).isNotNull();
+//        assertThat(result.getTotalElements()).isEqualTo(2);
+//    }
+
+//    @DisplayName("키워드 없이 검색시 위치 기반으로 반경 내에 모집글을 반환한다")
+//    @Test
+//    void findAllNearByLocationWithNull() {
+//        // given
+//        Pageable pageable = getPageable();
+//
+//        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
+//                .keyword("")
+//                .latitude(37.5935)
+//                .longitude(126.9780)
+//                .radius(5.0)
+//                .pageable(pageable)
+//                .build();
+//
+//        // when
+//        Page<RecruitBoardDetail> result = recruitBoardRepository.findAllNearby(condition);
+//
+//        // then
+//        assertThat(result).isNotNull();
+//        assertThat(result.getTotalElements()).isEqualTo(28);
+//    }
 
     @DisplayName("기관 아이디로 모집글 리스트를 조회할 수 있다.")
     @Test
@@ -435,6 +481,7 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
         //given
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .keyword("저장")
                 .pageable(pageable)
                 .build();
 
@@ -451,7 +498,7 @@ class RecruitBoardRepositoryImplTest extends IntegrationTestSupport {
         recruitBoardRepository.saveDocuments(recruitBoards);
 
         //then
-        Page<RecruitBoardWithCenter> findBoard = recruitBoardRepository.findByRecruitBoardsContaining("저장", condition);
+        Page<RecruitBoardWithCenter> findBoard = recruitBoardRepository.findByRecruitBoardsContaining(condition);
 
         assertThat(findBoard).isNotNull();
         assertThat(findBoard.getTotalElements()).isEqualTo(2);

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
@@ -6,7 +6,9 @@ import com.somemore.center.repository.center.CenterRepository;
 import com.somemore.location.domain.Location;
 import com.somemore.location.repository.LocationRepository;
 import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardNearByCondition;
 import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
+import com.somemore.recruitboard.dto.response.RecruitBoardDetailResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
 import com.somemore.recruitboard.repository.RecruitBoardRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +34,9 @@ public class RecruitBoardDocumentServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RecruitBoardDocumentService recruitBoardDocumentService;
+
+    @Autowired
+    private RecruitBoardQueryService recruitBoardQueryService;
 
     @Autowired
     private RecruitBoardRepository recruitBoardRepository;
@@ -66,11 +71,12 @@ public class RecruitBoardDocumentServiceTest extends IntegrationTestSupport {
         //given
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .keyword("노인")
                 .pageable(pageable)
                 .build();
 
         //when
-        Page<RecruitBoardWithCenterResponseDto> dtos = recruitBoardDocumentService.getRecruitBoardBySearch("노인", condition);
+        Page<RecruitBoardWithCenterResponseDto> dtos = recruitBoardDocumentService.getRecruitBoardBySearch(condition);
 
         //then
         assertThat(dtos).isNotNull();
@@ -79,6 +85,50 @@ public class RecruitBoardDocumentServiceTest extends IntegrationTestSupport {
         assertThat(dtos.getSize()).isEqualTo(5);
         assertThat(dtos.getTotalPages()).isEqualTo(1);
     }
+
+//    @DisplayName("위치 기반으로 주변 모집글을 페이징하여 조회할 수 있다")
+//    @Test
+//    void getRecruitBoardsNearBy() {
+//        // given
+//        Pageable pageable = getPageable();
+//        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
+//                .keyword(null)
+//                .latitude(37.5935)
+//                .longitude(126.9780)
+//                .radius(5.0)
+//                .pageable(pageable)
+//                .build();
+//
+//        // when
+//        Page<RecruitBoardDetailResponseDto> result = recruitBoardQueryService.getRecruitBoardsNearby(
+//                condition);
+//
+//        // then
+//        assertThat(result).isNotNull();
+//        assertThat(result.getTotalElements()).isEqualTo(23);
+//        assertThat(result.getContent()).isNotEmpty();
+//    }
+
+//    @DisplayName("키워드 없이 검색시 전체 모집글을 조회한다. (service)")
+//    @Test
+//    void getRecruitBoardBySearchWithNull() {
+//        //given
+//        Pageable pageable = getPageable();
+//        RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+//                .keyword("")
+//                .pageable(pageable)
+//                .build();
+//
+//        //when
+//        Page<RecruitBoardWithCenterResponseDto> dtos = recruitBoardDocumentService.getRecruitBoardBySearch(condition);
+//
+//        //then
+//        assertThat(dtos).isNotNull();
+//        assertThat(dtos.getContent()).isNotNull();
+//        assertThat(dtos.getTotalElements()).isEqualTo(23);
+//        assertThat(dtos.getSize()).isEqualTo(5);
+//        assertThat(dtos.getTotalPages()).isEqualTo(5);
+//    }
 
     private Pageable getPageable() {
         Sort sort = Sort.by(Sort.Order.desc("created_at"));

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
@@ -2,7 +2,7 @@ package com.somemore.recruitboard.service.query;
 
 import com.somemore.IntegrationTestSupport;
 import com.somemore.center.domain.Center;
-import com.somemore.center.repository.CenterRepository;
+import com.somemore.center.repository.center.CenterRepository;
 import com.somemore.location.domain.Location;
 import com.somemore.location.repository.LocationRepository;
 import com.somemore.recruitboard.domain.RecruitBoard;

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardDocumentServiceTest.java
@@ -1,0 +1,87 @@
+package com.somemore.recruitboard.service.query;
+
+import com.somemore.IntegrationTestSupport;
+import com.somemore.center.domain.Center;
+import com.somemore.center.repository.CenterRepository;
+import com.somemore.location.domain.Location;
+import com.somemore.location.repository.LocationRepository;
+import com.somemore.recruitboard.domain.RecruitBoard;
+import com.somemore.recruitboard.dto.condition.RecruitBoardSearchCondition;
+import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
+import com.somemore.recruitboard.repository.RecruitBoardRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.somemore.common.fixture.CenterFixture.createCenter;
+import static com.somemore.common.fixture.LocationFixture.createLocation;
+import static com.somemore.common.fixture.RecruitBoardFixture.createRecruitBoard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+public class RecruitBoardDocumentServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RecruitBoardDocumentService recruitBoardDocumentService;
+
+    @Autowired
+    private RecruitBoardRepository recruitBoardRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private CenterRepository centerRepository;
+
+    private final List<RecruitBoard> boards = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        Location location = createLocation();
+        locationRepository.save(location);
+
+        Center center = createCenter();
+        centerRepository.save(center);
+
+        for (int i = 1; i <= 30; i++) {
+            String title = "제목" + i;
+            RecruitBoard board = createRecruitBoard(title, center.getId(), location.getId());
+            boards.add(board);
+        }
+        recruitBoardRepository.saveAll(boards);
+    }
+
+    @DisplayName("검색 키워드가 포함된 모집글을 조회한다. (service)")
+    @Test
+    void getRecruitBoardBySearch() {
+        //given
+        Pageable pageable = getPageable();
+        RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .pageable(pageable)
+                .build();
+
+        //when
+        Page<RecruitBoardWithCenterResponseDto> dtos = recruitBoardDocumentService.getRecruitBoardBySearch("노인", condition);
+
+        //then
+        assertThat(dtos).isNotNull();
+        assertThat(dtos.getContent()).isNotNull();
+        assertThat(dtos.getTotalElements()).isEqualTo(4);
+        assertThat(dtos.getSize()).isEqualTo(5);
+        assertThat(dtos.getTotalPages()).isEqualTo(1);
+    }
+
+    private Pageable getPageable() {
+        Sort sort = Sort.by(Sort.Order.desc("created_at"));
+        return PageRequest.of(0, 5, sort);
+    }
+}

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
@@ -25,6 +25,8 @@ import com.somemore.recruitboard.dto.response.RecruitBoardResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithCenterResponseDto;
 import com.somemore.recruitboard.dto.response.RecruitBoardWithLocationResponseDto;
 import com.somemore.recruitboard.repository.RecruitBoardRepository;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,9 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RecruitBoardQueryService recruitBoardQueryService;
+
+    @Autowired
+    private RecruitBoardDocumentService recruitBoardDocumentService;
 
     @Autowired
     private RecruitBoardRepository recruitBoardRepository;
@@ -278,6 +283,40 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(all).hasSize(3);
+    }
+
+    @DisplayName("모집글을 elastic search index에 저장한다. (service)")
+    @Test
+    void saveRecruitBoardDocuments() {
+        //given
+        Center center = createCenter("특별한 기관");
+        centerRepository.save(center);
+
+        Pageable pageable = getPageable();
+        RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .pageable(pageable)
+                .build();
+
+        List<RecruitBoard> recruitBoards = new ArrayList<>();
+
+        RecruitBoard board1 = createRecruitBoard("저장 잘 되나요?", center.getId());
+        RecruitBoard savedBoard1 = recruitBoardRepository.save(board1);
+        RecruitBoard board2 = createRecruitBoard("저장해줘", center.getId());
+        RecruitBoard savedBoard2 = recruitBoardRepository.save(board2);
+        recruitBoards.add(savedBoard1);
+        recruitBoards.add(savedBoard2);
+
+        //when
+        recruitBoardDocumentService.saveRecruitBoardDocuments(recruitBoards);
+
+        //then
+        Page<RecruitBoardWithCenterResponseDto> findBoard = recruitBoardDocumentService.getRecruitBoardBySearch("저장", condition);
+
+        assertThat(findBoard).isNotNull();
+        assertThat(findBoard.getTotalElements()).isEqualTo(2);
+
+        recruitBoardRepository.deleteDocument(savedBoard1.getId());
+        recruitBoardRepository.deleteDocument(savedBoard2.getId());
     }
 
     private Pageable getPageable() {

--- a/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
+++ b/src/test/java/com/somemore/recruitboard/service/query/RecruitBoardQueryServiceTest.java
@@ -151,36 +151,6 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         assertThat(dtos.getContent().getFirst().center().name()).isEqualTo(name);
     }
 
-    @DisplayName("위치 기반으로 주변 모집글을 페이징하여 조회할 수 있다")
-    @Test
-    void getRecruitBoardsNearBy() {
-        // given
-        Center center = createCenter();
-        centerRepository.save(center);
-        Location location = createLocation();
-        locationRepository.save(location);
-
-        RecruitBoard board = createRecruitBoard(center.getId(), location.getId());
-        recruitBoardRepository.save(board);
-
-        Pageable pageable = getPageable();
-        RecruitBoardNearByCondition condition = RecruitBoardNearByCondition.builder()
-                .latitude(location.getLatitude().doubleValue())
-                .longitude(location.getLongitude().doubleValue())
-                .radius(3.0)
-                .pageable(pageable)
-                .build();
-
-        // when
-        Page<RecruitBoardDetailResponseDto> result = recruitBoardQueryService.getRecruitBoardsNearby(
-                condition);
-
-        // then
-        assertThat(result).isNotEmpty();
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent().getFirst().id()).isEqualTo(board.getId());
-    }
-
     @DisplayName("기관 아이디로 모집글을 페이징하여 조회할 수 있다")
     @Test
     void getRecruitBoardsByCenterId() {
@@ -294,6 +264,7 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
 
         Pageable pageable = getPageable();
         RecruitBoardSearchCondition condition = RecruitBoardSearchCondition.builder()
+                .keyword("저장")
                 .pageable(pageable)
                 .build();
 
@@ -310,7 +281,7 @@ class RecruitBoardQueryServiceTest extends IntegrationTestSupport {
         recruitBoardDocumentService.saveRecruitBoardDocuments(recruitBoards);
 
         //then
-        Page<RecruitBoardWithCenterResponseDto> findBoard = recruitBoardDocumentService.getRecruitBoardBySearch("저장", condition);
+        Page<RecruitBoardWithCenterResponseDto> findBoard = recruitBoardDocumentService.getRecruitBoardBySearch(condition);
 
         assertThat(findBoard).isNotNull();
         assertThat(findBoard.getTotalElements()).isEqualTo(2);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -60,7 +60,7 @@ cloud:
       static: ap-northeast-2
     s3:
       bucket: somemore
-      base-url: https://somemore-images.s3.ap-northeast-2.amazonaws.com/
+      base-url: https://somemore-image.s3.ap-northeast-2.amazonaws.com
     stack:
       auto: false
 
@@ -70,7 +70,7 @@ default:
 
 elastic:
   search:
-    uris: localhost:9200
+    uri: localhost:9200
     username: elastic
     password: somemore
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,6 +33,10 @@ spring:
       port: 6379
       password:  # 테스트에서는 비밀번호 없이 연결
 
+    elasticsearch:
+      repositories:
+        enabled: true
+
   web:
     locale: ko_KR
     locale-resolver: fixed
@@ -56,10 +60,21 @@ cloud:
       static: ap-northeast-2
     s3:
       bucket: somemore
-      base-url: https://somemore-image.s3.ap-northeast-2.amazonaws.com
+      base-url: https://somemore-images.s3.ap-northeast-2.amazonaws.com/
     stack:
       auto: false
 
 default:
   image:
     url: ""
+
+elastic:
+  search:
+    uris: localhost:9200
+    username: elastic
+    password: somemore
+
+management:
+  health:
+    elasticsearch:
+      enabled: false


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- resolved : #137 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 커뮤니티 게시글 키워드 검색 조회 (제목, 내용)
- 봉사활동 모집글 키워드 검색 조회 (제목, 내용)
- 봉사활동 위치기반 모집글 키워드 검색 조회 (제목, 내용)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

> - 봉사활동의 경우 기관명도 같이 조회하고 싶었는데 테이블이 한 번 조인되어있어 머리가 안돌아가서 추후에 리팩토링 하겠습니다..
> - 테스트는 elastic search에서 검색 결과 조회 해오는 부분이 개별로 실행해야만 성공해서 따로 두었습니다.
> - 코드가 좀 더러운 거 같은데 더 못보겠어서 pr 올립니다 아무거나 다 코드 리뷰로 말해주세요..

- 어제 코드 리뷰 반영하여 다시 pr 올립니다
- 지도에서 검색 추가 구현하였습니다.
- 키워드에 값이 없을 경우 전체 조회되도록 수정하였습니다.
- elastic search랑 연결된 조회는 전부 따로 test를 실행해야하는 건지.. 전체로 돌리면 안돼서 주석처리해뒀습니다. 전부 개별로 실행하면 성공합니다..!
- 서버 연결하고 다시 pr 올리겠습니다!