### PR TITLE
[REFACTOR] 리뷰 생성 및 컨트롤러 테스트 리팩토링

### DIFF
--- a/src/main/java/com/somemore/domains/review/service/CreateReviewService.java
+++ b/src/main/java/com/somemore/domains/review/service/CreateReviewService.java
@@ -11,6 +11,7 @@ import com.somemore.domains.review.domain.Review;
 import com.somemore.domains.review.dto.request.ReviewCreateRequestDto;
 import com.somemore.domains.review.usecase.CreateReviewUseCase;
 
+import com.somemore.global.exception.DuplicateException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ public class CreateReviewService implements CreateReviewUseCase {
     @Override
     public Long createReview(ReviewCreateRequestDto requestDto, UUID volunteerId, String imgUrl) {
         VolunteerApply apply = getVolunteerApply(requestDto.recruitBoardId(), volunteerId);
-        validateReviewNotExist(apply);
+        validateDuplicateReview(apply);
         validateActivityCompletion(apply);
 
         Review review = requestDto.toEntity(apply, volunteerId, imgUrl);
@@ -38,9 +39,9 @@ public class CreateReviewService implements CreateReviewUseCase {
         return volunteerApplyQueryUseCase.getByRecruitIdAndVolunteerId(recruitBoardId, volunteerId);
     }
 
-    private void validateReviewNotExist(VolunteerApply apply) {
+    private void validateDuplicateReview(VolunteerApply apply) {
         if (reviewRepository.existsByVolunteerApplyId(apply.getId())) {
-            throw new BadRequestException(REVIEW_ALREADY_EXISTS.getMessage());
+            throw new DuplicateException(REVIEW_ALREADY_EXISTS);
         }
     }
 
@@ -48,6 +49,6 @@ public class CreateReviewService implements CreateReviewUseCase {
         if (apply.isVolunteerActivityCompleted()) {
             return;
         }
-        throw new BadRequestException(REVIEW_RESTRICTED_TO_ATTENDED.getMessage());
+        throw new BadRequestException(REVIEW_RESTRICTED_TO_ATTENDED);
     }
 }

--- a/src/main/java/com/somemore/domains/volunteerapply/service/VolunteerApplyQueryService.java
+++ b/src/main/java/com/somemore/domains/volunteerapply/service/VolunteerApplyQueryService.java
@@ -8,8 +8,7 @@ import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyResponseDt
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.domains.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryUseCase;
-import com.somemore.global.exception.BadRequestException;
-
+import com.somemore.global.exception.NoSuchElementException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +34,7 @@ public class VolunteerApplyQueryService implements VolunteerApplyQueryUseCase {
     public VolunteerApply getByRecruitIdAndVolunteerId(Long recruitId, UUID volunteerId) {
         return volunteerApplyRepository.findByRecruitIdAndVolunteerId(recruitId, volunteerId)
                 .orElseThrow(
-                        () -> new BadRequestException(NOT_EXISTS_VOLUNTEER_APPLY));
+                        () -> new NoSuchElementException(NOT_EXISTS_VOLUNTEER_APPLY));
     }
 
     @Override
@@ -49,7 +48,7 @@ public class VolunteerApplyQueryService implements VolunteerApplyQueryUseCase {
 
     @Override
     public VolunteerApplyResponseDto getVolunteerApplyByRecruitIdAndVolunteerId(Long recruitId,
-                                                                                UUID volunteerId) {
+            UUID volunteerId) {
         VolunteerApply apply = getByRecruitIdAndVolunteerId(recruitId, volunteerId);
 
         return VolunteerApplyResponseDto.from(apply);

--- a/src/main/java/com/somemore/global/exception/DuplicateException.java
+++ b/src/main/java/com/somemore/global/exception/DuplicateException.java
@@ -2,6 +2,9 @@ package com.somemore.global.exception;
 
 public class DuplicateException extends RuntimeException{
 
+    public DuplicateException(final ExceptionMessage message) {
+        super(message.getMessage());
+    }
     public DuplicateException(final String message) {
         super(message);
     }

--- a/src/main/java/com/somemore/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/somemore/global/exception/handler/GlobalExceptionHandler.java
@@ -49,10 +49,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ProblemDetail handleMethodArgumentNotValid(final MethodArgumentNotValidException e) {
 
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        String errorMessage = e.getBindingResult().getAllErrors().getFirst().getDefaultMessage();
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, errorMessage);
 
         problemDetail.setTitle("유효성 예외");
-        problemDetail.setDetail("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
 
         return problemDetail;
     }

--- a/src/test/java/com/somemore/domains/center/controller/CenterProfileCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/center/controller/CenterProfileCommandApiControllerTest.java
@@ -1,41 +1,30 @@
 package com.somemore.domains.center.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.somemore.domains.center.dto.request.CenterProfileUpdateRequestDto;
-import com.somemore.domains.center.usecase.command.UpdateCenterProfileUseCase;
-import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
-
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.somemore.domains.center.dto.request.CenterProfileUpdateRequestDto;
+import com.somemore.domains.center.usecase.command.UpdateCenterProfileUseCase;
+import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
 class CenterProfileCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private UpdateCenterProfileUseCase updateCenterProfileUseCase;
@@ -92,7 +81,6 @@ class CenterProfileCommandApiControllerTest extends ControllerTestSupport {
                         .header("Authorization", "Bearer access-token"))
 
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isEmpty())

--- a/src/test/java/com/somemore/domains/center/controller/CenterQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/center/controller/CenterQueryApiControllerTest.java
@@ -1,24 +1,24 @@
 package com.somemore.domains.center.controller;
 
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_CENTER;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.center.dto.response.CenterProfileResponseDto;
 import com.somemore.domains.center.usecase.query.CenterQueryUseCase;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.support.ControllerTestSupport;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_CENTER;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class CenterQueryApiControllerTest extends ControllerTestSupport {
 
@@ -53,16 +53,18 @@ class CenterQueryApiControllerTest extends ControllerTestSupport {
                         get("/api/center/profile/{centerId}", centerId)
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.message").value("기관 프로필 조회 성공"))
                 .andExpect(jsonPath("$.data.center_id").value(centerId.toString())) // center_id로 수정
                 .andExpect(jsonPath("$.data.name").value("Test Center"))
-                .andExpect(jsonPath("$.data.contact_number").value("010-1234-5678")) // contact_number로 수정
-                .andExpect(jsonPath("$.data.img_url").value("http://example.com/image.jpg")) // img_url로 수정
+                .andExpect(jsonPath("$.data.contact_number").value(
+                        "010-1234-5678")) // contact_number로 수정
+                .andExpect(jsonPath("$.data.img_url").value(
+                        "http://example.com/image.jpg")) // img_url로 수정
                 .andExpect(jsonPath("$.data.introduce").value("This is a test center."))
-                .andExpect(jsonPath("$.data.homepage_link").value("http://example.com")) // homepage_link로 수정
+                .andExpect(jsonPath("$.data.homepage_link").value(
+                        "http://example.com")) // homepage_link로 수정
                 .andExpect(jsonPath("$.data.prefer_items").isArray()); // prefer_items로 수정
 
         verify(centerQueryUseCase, times(1)).getCenterProfileByCenterId(centerId);
@@ -81,7 +83,6 @@ class CenterQueryApiControllerTest extends ControllerTestSupport {
                         get("/api/center/profile/{centerId}", nonExistentCenterId)
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
-                .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value("400"))
                 .andExpect(jsonPath("$.detail").value("존재하지 않는 기관입니다."));

--- a/src/test/java/com/somemore/domains/center/controller/PreferItemCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/center/controller/PreferItemCommandApiControllerTest.java
@@ -1,19 +1,5 @@
 package com.somemore.domains.center.controller;
 
-import com.somemore.domains.center.dto.request.PreferItemCreateRequestDto;
-import com.somemore.domains.center.dto.response.PreferItemCreateResponseDto;
-import com.somemore.domains.center.usecase.command.CreatePreferItemUseCase;
-import com.somemore.domains.center.usecase.command.DeletePreferItemUseCase;
-import com.somemore.global.exception.BadRequestException;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-
-import java.util.UUID;
-
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -21,6 +7,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.somemore.domains.center.dto.request.PreferItemCreateRequestDto;
+import com.somemore.domains.center.dto.response.PreferItemCreateResponseDto;
+import com.somemore.domains.center.usecase.command.CreatePreferItemUseCase;
+import com.somemore.domains.center.usecase.command.DeletePreferItemUseCase;
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 
 class PreferItemCommandApiControllerTest extends ControllerTestSupport {
 

--- a/src/test/java/com/somemore/domains/community/controller/CommunityBoardCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/community/controller/CommunityBoardCommandApiControllerTest.java
@@ -1,6 +1,15 @@
 package com.somemore.domains.community.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.community.dto.request.CommunityBoardCreateRequestDto;
 import com.somemore.domains.community.dto.request.CommunityBoardUpdateRequestDto;
 import com.somemore.domains.community.usecase.board.CreateCommunityBoardUseCase;
@@ -9,37 +18,17 @@ import com.somemore.domains.community.usecase.board.UpdateCommunityBoardUseCase;
 import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
 import com.somemore.support.ControllerTestSupport;
 import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 public class CommunityBoardCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private CreateCommunityBoardUseCase createCommunityBoardUseCase;
@@ -86,10 +75,10 @@ public class CommunityBoardCommandApiControllerTest extends ControllerTestSuppor
 
         //when
         mockMvc.perform(multipart("/api/community-board")
-                    .file(requestData)
-                    .file(imageFile)
-                    .contentType(MULTIPART_FORM_DATA)
-                    .header("Authorization", "Bearer access-token"))
+                        .file(requestData)
+                        .file(imageFile)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
                 //then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(201))
@@ -138,13 +127,12 @@ public class CommunityBoardCommandApiControllerTest extends ControllerTestSuppor
 
         //when
         mockMvc.perform(builder
-                .file(requestData)
-                .file(imageFile)
-                .contentType(MULTIPART_FORM_DATA)
-                .header("Authorization", "Bearer access-token"))
+                        .file(requestData)
+                        .file(imageFile)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
 
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isEmpty())
@@ -157,13 +145,13 @@ public class CommunityBoardCommandApiControllerTest extends ControllerTestSuppor
     void deleteCommunityBoard_success() throws Exception {
         //given
         Long communityBoardId = 1L;
-        willDoNothing().given(deleteCommunityBoardUseCase).deleteCommunityBoard(any(UUID.class), any());
+        willDoNothing().given(deleteCommunityBoardUseCase)
+                .deleteCommunityBoard(any(UUID.class), any());
 
         //when
         mockMvc.perform(delete("/api/community-board/{id}", communityBoardId)
-                .header("Authorization", "Bearer access-token"))
+                        .header("Authorization", "Bearer access-token"))
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("커뮤니티 게시글 삭제 성공"))

--- a/src/test/java/com/somemore/domains/community/controller/CommunityBoardQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/community/controller/CommunityBoardQueryApiControllerTest.java
@@ -1,21 +1,5 @@
 package com.somemore.domains.community.controller;
 
-import com.somemore.domains.community.dto.response.CommunityBoardDetailResponseDto;
-import com.somemore.domains.community.dto.response.CommunityBoardResponseDto;
-import com.somemore.domains.community.usecase.board.CommunityBoardQueryUseCase;
-import com.somemore.support.ControllerTestSupport;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
@@ -25,10 +9,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport {
+import com.somemore.domains.community.dto.response.CommunityBoardDetailResponseDto;
+import com.somemore.domains.community.dto.response.CommunityBoardResponseDto;
+import com.somemore.domains.community.usecase.board.CommunityBoardQueryUseCase;
+import com.somemore.support.ControllerTestSupport;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
 
-    @Autowired
-    private MockMvc mockMvc;
+public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport {
 
     @MockBean
     private CommunityBoardQueryUseCase communityBoardQueryUseCase;
@@ -48,7 +42,7 @@ public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport 
         //when
         //then
         mockMvc.perform(get("/api/community-boards")
-                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").exists())
@@ -88,7 +82,8 @@ public class CommunityBoardQueryApiControllerTest extends ControllerTestSupport 
     void getById() throws Exception {
         //given
         Long communityBoardId = 1L;
-        CommunityBoardDetailResponseDto responseDto = CommunityBoardDetailResponseDto.builder().build();
+        CommunityBoardDetailResponseDto responseDto = CommunityBoardDetailResponseDto.builder()
+                .build();
         given(communityBoardQueryUseCase.getCommunityBoardDetail(any()))
                 .willReturn(responseDto);
 

--- a/src/test/java/com/somemore/domains/community/controller/CommunityCommentCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/community/controller/CommunityCommentCommandApiControllerTest.java
@@ -1,6 +1,16 @@
 package com.somemore.domains.community.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.community.dto.request.CommunityCommentCreateRequestDto;
 import com.somemore.domains.community.dto.request.CommunityCommentUpdateRequestDto;
 import com.somemore.domains.community.usecase.comment.CreateCommunityCommentUseCase;
@@ -8,31 +18,13 @@ import com.somemore.domains.community.usecase.comment.DeleteCommunityCommentUseC
 import com.somemore.domains.community.usecase.comment.UpdateCommunityCommentUseCase;
 import com.somemore.support.ControllerTestSupport;
 import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class CommunityCommentCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private CreateCommunityCommentUseCase createCommunityCommentUseCase;
@@ -85,7 +77,8 @@ public class CommunityCommentCommandApiControllerTest extends ControllerTestSupp
                 .updateCommunityComment(any(), any(), any(UUID.class), any());
 
         //when
-        mockMvc.perform(put("/api/community-board/{boardId}/comment/{id}", communityBoardId, communityCommentId)
+        mockMvc.perform(put("/api/community-board/{boardId}/comment/{id}", communityBoardId,
+                        communityCommentId)
                         .content(objectMapper.writeValueAsString(requestDto))
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer access-token"))
@@ -102,13 +95,14 @@ public class CommunityCommentCommandApiControllerTest extends ControllerTestSupp
     @WithMockCustomUser
     void deleteCommunityComment_success() throws Exception {
         //given
-        willDoNothing().given(deleteCommunityCommentUseCase).deleteCommunityComment(any(UUID.class), any(), any());
+        willDoNothing().given(deleteCommunityCommentUseCase)
+                .deleteCommunityComment(any(UUID.class), any(), any());
 
         //when
-        mockMvc.perform(delete("/api/community-board/{boardId}/comment/{id}", communityBoardId, communityCommentId)
+        mockMvc.perform(delete("/api/community-board/{boardId}/comment/{id}", communityBoardId,
+                        communityCommentId)
                         .header("Authorization", "Bearer access-token"))
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("커뮤니티 댓글 삭제 성공"))

--- a/src/test/java/com/somemore/domains/community/controller/CommunityCommentQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/community/controller/CommunityCommentQueryApiControllerTest.java
@@ -1,19 +1,5 @@
 package com.somemore.domains.community.controller;
 
-import com.somemore.domains.community.dto.response.CommunityCommentResponseDto;
-import com.somemore.domains.community.usecase.comment.CommunityCommentQueryUseCase;
-import com.somemore.support.ControllerTestSupport;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
@@ -23,10 +9,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class CommunityCommentQueryApiControllerTest extends ControllerTestSupport {
+import com.somemore.domains.community.dto.response.CommunityCommentResponseDto;
+import com.somemore.domains.community.usecase.comment.CommunityCommentQueryUseCase;
+import com.somemore.support.ControllerTestSupport;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
 
-    @Autowired
-    private MockMvc mockMvc;
+public class CommunityCommentQueryApiControllerTest extends ControllerTestSupport {
 
     @MockBean
     private CommunityCommentQueryUseCase communityCommentQueryUseCase;
@@ -44,7 +38,7 @@ public class CommunityCommentQueryApiControllerTest extends ControllerTestSuppor
         //when
         //then
         mockMvc.perform(get("/api/community-board/{boardId}/comments", communityBoardId)
-                .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").exists())

--- a/src/test/java/com/somemore/domains/recruitboard/controller/RecruitBoardCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/recruitboard/controller/RecruitBoardCommandApiControllerTest.java
@@ -1,6 +1,20 @@
 package com.somemore.domains.recruitboard.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static com.somemore.domains.recruitboard.domain.RecruitStatus.CLOSED;
+import static com.somemore.domains.recruitboard.domain.VolunteerCategory.OTHER;
+import static com.somemore.support.fixture.LocalDateTimeFixture.createStartDateTime;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.location.dto.request.LocationCreateRequestDto;
 import com.somemore.domains.recruitboard.domain.RecruitStatus;
 import com.somemore.domains.recruitboard.dto.request.RecruitBoardCreateRequestDto;
@@ -13,41 +27,19 @@ import com.somemore.domains.recruitboard.usecase.command.UpdateRecruitBoardUseCa
 import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
 import com.somemore.support.ControllerTestSupport;
 import com.somemore.support.annotation.WithMockCustomUser;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import static com.somemore.domains.recruitboard.domain.RecruitStatus.CLOSED;
-import static com.somemore.domains.recruitboard.domain.VolunteerCategory.OTHER;
-import static com.somemore.support.fixture.LocalDateTimeFixture.createStartDateTime;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.http.MediaType.MULTIPART_FORM_DATA;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 class RecruitBoardCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private CreateRecruitBoardUseCase createRecruitBoardUseCase;
@@ -176,7 +168,6 @@ class RecruitBoardCommandApiControllerTest extends ControllerTestSupport {
                         .contentType(MULTIPART_FORM_DATA)
                         .header("Authorization", "Bearer access-token"))
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isEmpty())
@@ -206,7 +197,6 @@ class RecruitBoardCommandApiControllerTest extends ControllerTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer access-token"))
                 // then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isEmpty())
@@ -231,7 +221,6 @@ class RecruitBoardCommandApiControllerTest extends ControllerTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer access-token"))
                 //then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("봉사 활동 모집글 상태 수정 성공"))
@@ -250,7 +239,6 @@ class RecruitBoardCommandApiControllerTest extends ControllerTestSupport {
         mockMvc.perform(delete("/api/recruit-board/{id}", recruitBoardId)
                         .header("Authorization", "Bearer access-token"))
                 // then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("봉사 활동 모집글 삭제 성공"))

--- a/src/test/java/com/somemore/domains/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/recruitboard/controller/RecruitBoardQueryApiControllerTest.java
@@ -1,5 +1,15 @@
 package com.somemore.domains.recruitboard.controller;
 
+import static com.somemore.domains.recruitboard.domain.VolunteerCategory.ADMINISTRATIVE_SUPPORT;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.recruitboard.dto.condition.RecruitBoardNearByCondition;
 import com.somemore.domains.recruitboard.dto.condition.RecruitBoardSearchCondition;
 import com.somemore.domains.recruitboard.dto.response.RecruitBoardDetailResponseDto;
@@ -8,30 +18,16 @@ import com.somemore.domains.recruitboard.dto.response.RecruitBoardWithCenterResp
 import com.somemore.domains.recruitboard.dto.response.RecruitBoardWithLocationResponseDto;
 import com.somemore.domains.recruitboard.usecase.query.RecruitBoardQueryUseCase;
 import com.somemore.support.ControllerTestSupport;
+import java.util.Collections;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-import java.util.UUID;
-
-import static com.somemore.domains.recruitboard.domain.VolunteerCategory.ADMINISTRATIVE_SUPPORT;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class RecruitBoardQueryApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
 
     @MockBean
     private RecruitBoardQueryUseCase recruitBoardQueryUseCase;

--- a/src/test/java/com/somemore/domains/review/controller/ReviewCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/review/controller/ReviewCommandApiControllerTest.java
@@ -1,21 +1,5 @@
 package com.somemore.domains.review.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.somemore.domains.review.dto.request.ReviewCreateRequestDto;
-import com.somemore.domains.review.usecase.CreateReviewUseCase;
-import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -24,13 +8,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.somemore.domains.review.dto.request.ReviewCreateRequestDto;
+import com.somemore.domains.review.usecase.CreateReviewUseCase;
+import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
 class ReviewCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private ImageUploadUseCase imageUploadUseCase;
@@ -38,7 +29,7 @@ class ReviewCommandApiControllerTest extends ControllerTestSupport {
     @MockBean
     private CreateReviewUseCase createReviewUseCase;
 
-    @DisplayName("리뷰 생성")
+    @DisplayName("리뷰 생성 성공")
     @Test
     @WithMockCustomUser()
     void createReview() throws Exception {
@@ -56,12 +47,7 @@ class ReviewCommandApiControllerTest extends ControllerTestSupport {
                 "test image content".getBytes()
         );
 
-        MockMultipartFile requestData = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(requestDto)
-        );
+        MockMultipartFile requestData = getRequestData(requestDto);
 
         String imgUrl = "https://example.com/image/test-image.jpg";
         Long reviewId = 1L;
@@ -81,5 +67,93 @@ class ReviewCommandApiControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.code").value(201))
                 .andExpect(jsonPath("$.data").value(reviewId))
                 .andExpect(jsonPath("$.message").value("리뷰 등록 성공"));
+    }
+
+    @DisplayName("리뷰 생성 유효성 테스트 - 모집글 아이디")
+    @Test
+    @WithMockCustomUser()
+    void createReviewValidateTestRecruitBoardId() throws Exception {
+        // given
+        ReviewCreateRequestDto requestDto = ReviewCreateRequestDto.builder()
+                .title("리뷰 제목")
+                .content("리뷰 내용")
+                .build();
+
+        MockMultipartFile requestData = getRequestData(requestDto);
+
+        given(imageUploadUseCase.uploadImage(any())).willReturn("");
+
+        // when
+        mockMvc.perform(multipart("/api/review")
+                        .file(requestData)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("유효성 예외"))
+                .andExpect(jsonPath("$.detail").value("봉사 모집글 아이디는 필수 값입니다."));
+    }
+
+    @DisplayName("리뷰 생성 유효성 테스트 - 제목")
+    @Test
+    @WithMockCustomUser()
+    void createReviewValidateTestTitle() throws Exception {
+        // given
+        ReviewCreateRequestDto requestDto = ReviewCreateRequestDto.builder()
+                .recruitBoardId(1L)
+                .content("리뷰 내용")
+                .build();
+
+        MockMultipartFile requestData = getRequestData(requestDto);
+
+        given(imageUploadUseCase.uploadImage(any())).willReturn("");
+
+        // when
+        mockMvc.perform(multipart("/api/review")
+                        .file(requestData)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("유효성 예외"))
+                .andExpect(jsonPath("$.detail").value("리뷰 제목은 필수 값입니다."));
+    }
+
+    @DisplayName("리뷰 생성 유효성 테스트 - 내용")
+    @Test
+    @WithMockCustomUser()
+    void createReviewValidateTestContent() throws Exception {
+        // given
+        ReviewCreateRequestDto requestDto = ReviewCreateRequestDto.builder()
+                .recruitBoardId(1L)
+                .title("리뷰 제목")
+                .build();
+
+        MockMultipartFile requestData = getRequestData(requestDto);
+
+        given(imageUploadUseCase.uploadImage(any())).willReturn("");
+
+        // when
+        mockMvc.perform(multipart("/api/review")
+                        .file(requestData)
+                        .contentType(MULTIPART_FORM_DATA)
+                        .header("Authorization", "Bearer access-token"))
+                // then
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("유효성 예외"))
+                .andExpect(jsonPath("$.detail").value("리뷰 내용은 필수 값입니다."));
+    }
+
+    private MockMultipartFile getRequestData(ReviewCreateRequestDto requestDto)
+            throws JsonProcessingException {
+        return new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(requestDto)
+        );
     }
 }

--- a/src/test/java/com/somemore/domains/review/service/CreateReviewServiceTest.java
+++ b/src/test/java/com/somemore/domains/review/service/CreateReviewServiceTest.java
@@ -6,6 +6,7 @@ import com.somemore.domains.review.repository.ReviewRepository;
 import com.somemore.domains.volunteerapply.domain.VolunteerApply;
 import com.somemore.domains.volunteerapply.repository.VolunteerApplyRepository;
 import com.somemore.global.exception.BadRequestException;
+import com.somemore.global.exception.DuplicateException;
 import com.somemore.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -124,7 +125,7 @@ class CreateReviewServiceTest extends IntegrationTestSupport {
         // then
         assertThatThrownBy(
                 () -> createReviewService.createReview(requestDto, volunteerId, "")
-        ).isInstanceOf(BadRequestException.class)
+        ).isInstanceOf(DuplicateException.class)
                 .hasMessage(REVIEW_ALREADY_EXISTS.getMessage());
     }
 

--- a/src/test/java/com/somemore/domains/volunteer/controller/VolunteerProfileCommandControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteer/controller/VolunteerProfileCommandControllerTest.java
@@ -1,25 +1,5 @@
 package com.somemore.domains.volunteer.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.somemore.domains.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
-import com.somemore.domains.volunteer.usecase.UpdateVolunteerProfileUseCase;
-import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -30,10 +10,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
+import com.somemore.domains.volunteer.dto.request.VolunteerProfileUpdateRequestDto;
+import com.somemore.domains.volunteer.usecase.UpdateVolunteerProfileUseCase;
+import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
 
     @MockBean
     private UpdateVolunteerProfileUseCase updateVolunteerProfileUseCase;
@@ -69,7 +59,6 @@ class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
                         .contentType(MULTIPART_FORM_DATA)
                         .header("Authorization", "Bearer access-token"))
                 // then
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data").isEmpty())
@@ -98,15 +87,9 @@ class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
                         .contentType(MULTIPART_FORM_DATA)
                         .header("Authorization", "Bearer access-token"))
                 .andExpect(status().isBadRequest())
-                .andDo(result -> {
-                    String responseBody = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-                    Map<String, Object> jsonResponse = objectMapper.readValue(responseBody, new TypeReference<>() {
-                    });
-                    String detail = (String) jsonResponse.get("detail");
-
-                    assertThat(detail).isEqualTo("닉네임은 최대 10자까지 입력 가능합니다.");
-                });
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("유효성 예외"))
+                .andExpect(jsonPath("$.detail").value("닉네임은 최대 10자까지 입력 가능합니다."));
     }
 
     @DisplayName("봉사자 프로필 수정의 소개 유효성 검사 실패 테스트")
@@ -138,15 +121,9 @@ class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
                         .contentType(MULTIPART_FORM_DATA)
                         .header("Authorization", "Bearer access-token"))
                 .andExpect(status().isBadRequest())
-                .andDo(result -> {
-                    String responseBody = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-                    Map<String, Object> jsonResponse = objectMapper.readValue(responseBody, new TypeReference<>() {
-                    });
-                    String detail = (String) jsonResponse.get("detail");
-
-                    assertThat(detail).isEqualTo("소개글은 최대 100자까지 입력 가능합니다.");
-                });
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.title").value("유효성 예외"))
+                .andExpect(jsonPath("$.detail").value("소개글은 최대 100자까지 입력 가능합니다."));
     }
 
     private MockMultipartFile createMockImageFile() {

--- a/src/test/java/com/somemore/domains/volunteer/controller/VolunteerProfileCommandControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteer/controller/VolunteerProfileCommandControllerTest.java
@@ -105,7 +105,7 @@ class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
                     });
                     String detail = (String) jsonResponse.get("detail");
 
-                    assertThat(detail).isEqualTo("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
+                    assertThat(detail).isEqualTo("닉네임은 최대 10자까지 입력 가능합니다.");
                 });
     }
 
@@ -145,7 +145,7 @@ class VolunteerProfileCommandControllerTest extends ControllerTestSupport {
                     });
                     String detail = (String) jsonResponse.get("detail");
 
-                    assertThat(detail).isEqualTo("입력 데이터 유효성 검사가 실패했습니다. 각 필드를 확인해주세요.");
+                    assertThat(detail).isEqualTo("소개글은 최대 100자까지 입력 가능합니다.");
                 });
     }
 

--- a/src/test/java/com/somemore/domains/volunteerapply/controller/CenterVolunteerApplyCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteerapply/controller/CenterVolunteerApplyCommandApiControllerTest.java
@@ -1,21 +1,5 @@
 package com.somemore.domains.volunteerapply.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.somemore.domains.volunteerapply.dto.request.VolunteerApplySettleRequestDto;
-import com.somemore.domains.volunteerapply.usecase.ApproveVolunteerApplyUseCase;
-import com.somemore.domains.volunteerapply.usecase.RejectVolunteerApplyUseCase;
-import com.somemore.domains.volunteerapply.usecase.SettleVolunteerApplyFacadeUseCase;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -24,10 +8,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class CenterVolunteerApplyCommandApiControllerTest extends ControllerTestSupport {
+import com.somemore.domains.volunteerapply.dto.request.VolunteerApplySettleRequestDto;
+import com.somemore.domains.volunteerapply.usecase.ApproveVolunteerApplyUseCase;
+import com.somemore.domains.volunteerapply.usecase.RejectVolunteerApplyUseCase;
+import com.somemore.domains.volunteerapply.usecase.SettleVolunteerApplyFacadeUseCase;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-    @Autowired
-    private MockMvc mockMvc;
+class CenterVolunteerApplyCommandApiControllerTest extends ControllerTestSupport {
 
     @MockBean
     private ApproveVolunteerApplyUseCase approveVolunteerApplyUseCase;
@@ -37,9 +30,6 @@ class CenterVolunteerApplyCommandApiControllerTest extends ControllerTestSupport
 
     @MockBean
     private SettleVolunteerApplyFacadeUseCase settleVolunteerApplyFacadeUseCase;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("봉사 활동 지원 승인 성공 테스트")

--- a/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyCommandApiControllerTest.java
@@ -1,19 +1,5 @@
 package com.somemore.domains.volunteerapply.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.somemore.domains.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
-import com.somemore.domains.volunteerapply.usecase.ApplyVolunteerApplyUseCase;
-import com.somemore.domains.volunteerapply.usecase.WithdrawVolunteerApplyUseCase;
-import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -23,13 +9,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.somemore.domains.volunteerapply.dto.request.VolunteerApplyCreateRequestDto;
+import com.somemore.domains.volunteerapply.usecase.ApplyVolunteerApplyUseCase;
+import com.somemore.domains.volunteerapply.usecase.WithdrawVolunteerApplyUseCase;
+import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
 class VolunteerApplyCommandApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private ApplyVolunteerApplyUseCase applyVolunteerApplyUseCase;
@@ -68,7 +58,7 @@ class VolunteerApplyCommandApiControllerTest extends ControllerTestSupport {
     @Test
     @DisplayName("봉사 활동 철회 성공 테스트")
     @WithMockCustomUser
-    void withdraw () throws Exception {
+    void withdraw() throws Exception {
         // given
         Long id = 1L;
 

--- a/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
@@ -1,5 +1,13 @@
 package com.somemore.domains.volunteerapply.controller;
 
+import static com.somemore.domains.volunteerapply.domain.ApplyStatus.WAITING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.somemore.domains.volunteerapply.dto.condition.VolunteerApplySearchCondition;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyRecruitInfoResponseDto;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyResponseDto;
@@ -9,29 +17,15 @@ import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryFacadeUseC
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import com.somemore.support.ControllerTestSupport;
 import com.somemore.support.annotation.WithMockCustomUser;
+import java.util.Collections;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-import java.util.UUID;
-
-import static com.somemore.domains.volunteerapply.domain.ApplyStatus.WAITING;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
-
-    @Autowired
-    private MockMvc mockMvc;
 
     @MockBean
     private VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;

--- a/src/test/java/com/somemore/domains/volunteerapply/service/VolunteerApplyQueryServiceTest.java
+++ b/src/test/java/com/somemore/domains/volunteerapply/service/VolunteerApplyQueryServiceTest.java
@@ -1,12 +1,22 @@
 package com.somemore.domains.volunteerapply.service;
 
+import static com.somemore.domains.volunteerapply.domain.ApplyStatus.APPROVED;
+import static com.somemore.domains.volunteerapply.domain.ApplyStatus.REJECTED;
+import static com.somemore.domains.volunteerapply.domain.ApplyStatus.WAITING;
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_VOLUNTEER_APPLY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.somemore.domains.volunteerapply.domain.ApplyStatus;
 import com.somemore.domains.volunteerapply.domain.VolunteerApply;
 import com.somemore.domains.volunteerapply.dto.condition.VolunteerApplySearchCondition;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyResponseDto;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.domains.volunteerapply.repository.VolunteerApplyRepository;
+import com.somemore.global.exception.NoSuchElementException;
 import com.somemore.support.IntegrationTestSupport;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +24,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
-
-import static com.somemore.domains.volunteerapply.domain.ApplyStatus.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 class VolunteerApplyQueryServiceTest extends IntegrationTestSupport {
@@ -191,6 +195,22 @@ class VolunteerApplyQueryServiceTest extends IntegrationTestSupport {
         assertThat(applies)
                 .extracting(VolunteerApply::getId)
                 .containsExactlyInAnyOrderElementsOf(ids);
+    }
+
+    @DisplayName("존재하지 않는 봉사 지원을 조회할 경우 에러가 발생한다.")
+    @Test
+    void getByRecruitIdAndVolunteerIdWhenNotExist() {
+        // given
+        Long wrongBoardId = 999L;
+        UUID wrongVolunteerId = UUID.randomUUID();
+
+        // when
+        // then
+        assertThatThrownBy(
+                () -> volunteerApplyQueryService.getByRecruitIdAndVolunteerId(wrongBoardId,
+                        wrongVolunteerId)
+        ).isInstanceOf(NoSuchElementException.class)
+                .hasMessage(NOT_EXISTS_VOLUNTEER_APPLY.getMessage());
     }
 
     private VolunteerApply createApply(UUID volunteerId, Long recruitId) {

--- a/src/test/java/com/somemore/support/ControllerTestSupport.java
+++ b/src/test/java/com/somemore/support/ControllerTestSupport.java
@@ -1,12 +1,18 @@
 package com.somemore.support;
 
 
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -17,5 +23,16 @@ public abstract class ControllerTestSupport {
     protected MockMvc mockMvc;
 
     @Autowired
+    private WebApplicationContext ctx;
+
+    @Autowired
     protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+    }
 }

--- a/src/test/java/com/somemore/support/ControllerTestSupport.java
+++ b/src/test/java/com/somemore/support/ControllerTestSupport.java
@@ -1,18 +1,12 @@
 package com.somemore.support;
 
 
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -23,16 +17,6 @@ public abstract class ControllerTestSupport {
     protected MockMvc mockMvc;
 
     @Autowired
-    private WebApplicationContext ctx;
-
-    @Autowired
     protected ObjectMapper objectMapper;
 
-    @BeforeEach
-    public void setup() {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
-                .addFilters(new CharacterEncodingFilter("UTF-8", true))
-                .alwaysDo(print())
-                .build();
-    }
 }


### PR DESCRIPTION
resolved :
 - #253 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
리뷰 생성 및 컨트롤러 테스트 리팩토링

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
-  리뷰 생성 리팩토링
- 컨트롤러 테스트 리팩토링
- globalExceptionHandler 일부 리팩토링
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- @Valid 유효성 실패시, meassge에 적용한 값이 출력되도록 변경했습니다.
  -  여러개 필드에서 유효성 실패시 우선 검사되어 실패한 메세지가 출력되도록 수정
- 컨트롤러 테스트시 항상 print()를 출력하도록 변경하고 한글 깨짐이 발생하지 않도록 수정

위 두 개가 중점적이긴한데 이거에 대해 괜찮은지 의견 부탁드릴게요