### PR TITLE
[FIX] 봉사자 특정 모집글 지원 상태 조회 API 수정

### DIFF
--- a/src/main/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiController.java
+++ b/src/main/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiController.java
@@ -9,6 +9,7 @@ import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyWithReview
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import com.somemore.global.auth.annotation.CurrentUser;
+import com.somemore.global.auth.annotation.RoleId;
 import com.somemore.global.common.response.ApiResponse;
 import com.somemore.global.exception.NoSuchElementException;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,11 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -37,17 +34,18 @@ public class VolunteerApplyQueryApiController {
     private final VolunteerApplyQueryUseCase volunteerApplyQueryUseCase;
     private final VolunteerApplyQueryFacadeUseCase volunteerApplyQueryFacadeUseCase;
 
-    @Operation(summary = "특정 모집글 봉사자 지원 단건 조회", description = "특정 모집글에 대한 봉사자 지원을 조회합니다.")
-    @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}")
-    public ApiResponse<VolunteerApplyWithReviewStatusResponseDto> getVolunteerApplyByRecruitIdAndVolunteerId(
+    @Secured("ROLE_VOLUNTEER")
+    @Operation(summary = "특정 모집글 봉사 지원 단건 조회", description = "특정 모집글에 대한 봉사 지원을 조회합니다.")
+    @GetMapping("/volunteer-apply/recruit-board/{recruitBoardId}")
+    public ApiResponse<VolunteerApplyWithReviewStatusResponseDto> getVolunteerApplyByRecruitBoardId(
             @PathVariable Long recruitBoardId,
-            @PathVariable UUID volunteerId
+            @RoleId UUID volunteerId
     ) {
         try {
             return ApiResponse.ok(
                     200,
                     volunteerApplyQueryFacadeUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId, volunteerId),
-                    "특정 모집글에 대한 봉사자 지원 단건 조회 성공"
+                    "특정 모집글에 대한 봉사 지원 단건 조회 성공"
             );
         } catch (NoSuchElementException e) {
             return ApiResponse.ok(210, null, "지원 내역이 없습니다.");

--- a/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/volunteerapply/controller/VolunteerApplyQueryApiControllerTest.java
@@ -2,13 +2,14 @@ package com.somemore.domains.volunteerapply.controller;
 
 import com.somemore.domains.volunteerapply.dto.condition.VolunteerApplySearchCondition;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyRecruitInfoResponseDto;
-import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyWithReviewStatusResponseDto;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplySummaryResponseDto;
 import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyVolunteerInfoResponseDto;
+import com.somemore.domains.volunteerapply.dto.response.VolunteerApplyWithReviewStatusResponseDto;
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryFacadeUseCase;
 import com.somemore.domains.volunteerapply.usecase.VolunteerApplyQueryUseCase;
 import com.somemore.global.exception.NoSuchElementException;
 import com.somemore.support.ControllerTestSupport;
+import com.somemore.support.annotation.MockUser;
 import com.somemore.support.annotation.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,12 +38,13 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
     private VolunteerApplyQueryFacadeUseCase volunteerApplyQueryFacadeUseCase;
 
 
-    @DisplayName("특정 모집글 봉사자 지원 단건 조회 성공 테스트")
+    @MockUser
+    @DisplayName("특정 모집글 봉사 지원 단건 조회 성공 테스트")
     @Test
-    void getVolunteerApplyByRecruitIdAndVolunteerId() throws Exception {
+    void getVolunteerApplyByRecruitBoardId() throws Exception {
         // given
         Long recruitBoardId = 1L;
-        UUID volunteerId = UUID.randomUUID();
+        UUID volunteerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 
         VolunteerApplyWithReviewStatusResponseDto response = VolunteerApplyWithReviewStatusResponseDto.builder()
                 .id(1L)
@@ -52,18 +54,15 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
                 .attended(false)
                 .build();
 
-        given(volunteerApplyQueryFacadeUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId,
-                volunteerId))
+        given(volunteerApplyQueryFacadeUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId, volunteerId))
                 .willReturn(response);
 
         // when & then
-        mockMvc.perform(
-                        get("/api/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}",
-                                recruitBoardId, volunteerId)
-                                .accept(APPLICATION_JSON))
+        mockMvc.perform(get("/api/volunteer-apply/recruit-board/{recruitBoardId}", recruitBoardId)
+                        .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("특정 모집글에 대한 봉사자 지원 단건 조회 성공"))
+                .andExpect(jsonPath("$.message").value("특정 모집글에 대한 봉사 지원 단건 조회 성공"))
                 .andExpect(jsonPath("$.data.id").value(1))
                 .andExpect(jsonPath("$.data.volunteer_id").value(volunteerId.toString()))
                 .andExpect(jsonPath("$.data.recruit_board_id").value(recruitBoardId))
@@ -71,21 +70,20 @@ class VolunteerApplyQueryApiControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.attended").value(false));
     }
 
+    @MockUser
     @DisplayName("특정 모집글 봉사자 지원 단건 조회 성공 테스트 - 지원 내역이 없는 경우")
     @Test
-    void getVolunteerApplyByRecruitIdAndVolunteerIdWhenDoesNotExist() throws Exception {
+    void getVolunteerApplyByRecruitBoardIdWhenDoesNotExist() throws Exception {
         // given
         Long recruitBoardId = 1L;
-        UUID volunteerId = UUID.randomUUID();
+        UUID volunteerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 
-        given(volunteerApplyQueryFacadeUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId,
-                volunteerId))
+        given(volunteerApplyQueryFacadeUseCase.getVolunteerApplyByRecruitIdAndVolunteerId(recruitBoardId, volunteerId))
                 .willThrow(new NoSuchElementException(NOT_EXISTS_VOLUNTEER_APPLY));
 
         // when & then
         mockMvc.perform(
-                        get("/api/volunteer-apply/recruit-board/{recruitBoardId}/volunteer/{volunteerId}",
-                                recruitBoardId, volunteerId)
+                        get("/api/volunteer-apply/recruit-board/{recruitBoardId}", recruitBoardId)
                                 .accept(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(210))


### PR DESCRIPTION
resolved : 
 - #329 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그인한 상태에서 API 요청으로 변경
 - /api/volunteer-apply/recruit-board/{recruit_board_id}
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/a21daaf9-3c43-4125-84c8-ad5aa0123926" />
