### PR TITLE
Refactor/339 기관 프로필 이미지 업데이트 리팩토링

### DIFF
--- a/src/main/java/com/somemore/center/controller/CenterCommandApiController.java
+++ b/src/main/java/com/somemore/center/controller/CenterCommandApiController.java
@@ -1,0 +1,37 @@
+package com.somemore.center.controller;
+
+import com.somemore.center.dto.request.CenterProfileImgUpdateRequestDto;
+import com.somemore.center.usecase.UpdateCenterProfileImgUseCase;
+import com.somemore.global.auth.annotation.UserId;
+import com.somemore.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "Center Command API", description = "기관 프로필 수정 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/center")
+@RestController
+public class CenterCommandApiController {
+
+    private final UpdateCenterProfileImgUseCase updateCenterProfileImgUseCase;
+
+    @Secured("ROLE_CENTER")
+    @Operation(summary = "기관 프로필 이미지 수정", description = "기관의 프로필 이미지를 수정합니다.")
+    @PutMapping("/profileImgUpdate")
+    public ApiResponse<String> updateCenterProfile(
+            @UserId UUID centerId,
+            CenterProfileImgUpdateRequestDto requestDto
+    ) {
+
+        String presignedUrl = updateCenterProfileImgUseCase.updateCenterProfileImg(centerId, requestDto);
+
+        return ApiResponse.ok(presignedUrl,"센터 프로필 수정 성공");
+    }
+}

--- a/src/main/java/com/somemore/center/dto/request/CenterProfileImgUpdateRequestDto.java
+++ b/src/main/java/com/somemore/center/dto/request/CenterProfileImgUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.somemore.center.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CenterProfileImgUpdateRequestDto(
+        @Schema(description = "파일 이름", example = "image.png")
+        String fileName
+) {
+}

--- a/src/main/java/com/somemore/center/service/UpdateCenterProfileImgService.java
+++ b/src/main/java/com/somemore/center/service/UpdateCenterProfileImgService.java
@@ -1,0 +1,46 @@
+package com.somemore.center.service;
+
+import com.somemore.center.domain.NEWCenter;
+import com.somemore.center.dto.request.CenterProfileImgUpdateRequestDto;
+import com.somemore.center.repository.NEWCenterRepository;
+import com.somemore.center.usecase.UpdateCenterProfileImgUseCase;
+import com.somemore.global.exception.BadRequestException;
+import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.user.dto.request.UpdateProfileImgUrlRequestDto;
+import com.somemore.user.usecase.UpdateProfileImgUrlUseCase;
+import com.somemore.user.usecase.UserQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.somemore.global.exception.ExceptionMessage.NOT_EXISTS_CENTER;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class UpdateCenterProfileImgService implements UpdateCenterProfileImgUseCase {
+
+    private final ImageUploadUseCase imageUploadUseCase;
+    private final UserQueryUseCase userQueryUseCase;
+    private final UpdateProfileImgUrlUseCase updateProfileImgUrlUseCase;
+    private final NEWCenterRepository centerRepository;
+
+    @Override
+    public String updateCenterProfileImg(UUID centerId, CenterProfileImgUpdateRequestDto requestDto) {
+
+        NEWCenter center = centerRepository.findById(centerId)
+                .orElseThrow(() -> new BadRequestException(NOT_EXISTS_CENTER));
+
+        String presignedUrl = imageUploadUseCase.getPresignedUrl(requestDto.fileName());
+
+        String fileUrl = presignedUrl.split("\\?")[0];
+
+        UpdateProfileImgUrlRequestDto updateProfileImgUrlRequestDto = new UpdateProfileImgUrlRequestDto(center.getUserId(), fileUrl);
+
+        updateProfileImgUrlUseCase.updateProfileImgUrl(updateProfileImgUrlRequestDto);
+
+        return presignedUrl;
+    }
+}

--- a/src/main/java/com/somemore/center/usecase/UpdateCenterProfileImgUseCase.java
+++ b/src/main/java/com/somemore/center/usecase/UpdateCenterProfileImgUseCase.java
@@ -1,0 +1,9 @@
+package com.somemore.center.usecase;
+
+import com.somemore.center.dto.request.CenterProfileImgUpdateRequestDto;
+
+import java.util.UUID;
+
+public interface UpdateCenterProfileImgUseCase {
+    String updateCenterProfileImg(UUID centerId, CenterProfileImgUpdateRequestDto requestDto);
+}

--- a/src/main/java/com/somemore/domains/center/controller/PreferItemCommandApiController.java
+++ b/src/main/java/com/somemore/domains/center/controller/PreferItemCommandApiController.java
@@ -4,7 +4,7 @@ import com.somemore.domains.center.dto.request.PreferItemCreateRequestDto;
 import com.somemore.domains.center.dto.response.PreferItemCreateResponseDto;
 import com.somemore.domains.center.usecase.command.CreatePreferItemUseCase;
 import com.somemore.domains.center.usecase.command.DeletePreferItemUseCase;
-import com.somemore.global.auth.annotation.CurrentUser;
+import com.somemore.global.auth.annotation.UserId;
 import com.somemore.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,9 +34,9 @@ public class PreferItemCommandApiController {
     @PostMapping()
     public ApiResponse<PreferItemCreateResponseDto> registerPreferItem(
             @Valid @RequestBody PreferItemCreateRequestDto requestDto,
-            @CurrentUser UUID userId) {
+            @UserId UUID centerId) {
 
-        PreferItemCreateResponseDto responseDto = createPreferItemUseCase.createPreferItem(userId,
+        PreferItemCreateResponseDto responseDto = createPreferItemUseCase.createPreferItem(centerId,
                 requestDto);
 
         return ApiResponse.ok(200, responseDto, "관심 기관 등록 성공");
@@ -45,7 +45,7 @@ public class PreferItemCommandApiController {
     @Secured("ROLE_CENTER")
     @Operation(summary = "기관 선호물품 삭제 API")
     @DeleteMapping("/{preferItemId}")
-    public ApiResponse<String> deletePreferItem(@CurrentUser UUID centerId, @PathVariable Long preferItemId) {
+    public ApiResponse<String> deletePreferItem(@UserId UUID centerId, @PathVariable Long preferItemId) {
 
         deletePreferItemUseCase.deletePreferItem(centerId, preferItemId);
 

--- a/src/main/java/com/somemore/user/domain/UserCommonAttribute.java
+++ b/src/main/java/com/somemore/user/domain/UserCommonAttribute.java
@@ -53,6 +53,10 @@ public class UserCommonAttribute extends BaseEntity {
         this.isCustomized = true;
     }
 
+    public void updateImgUrl(String imgUrl) {
+        this.imgUrl = imgUrl;
+    }
+
     public static UserCommonAttribute createDefault(UUID userId, UserRole role) {
         return UserCommonAttribute.builder()
                 .userId(userId)

--- a/src/main/java/com/somemore/user/dto/request/UpdateProfileImgUrlRequestDto.java
+++ b/src/main/java/com/somemore/user/dto/request/UpdateProfileImgUrlRequestDto.java
@@ -1,0 +1,9 @@
+package com.somemore.user.dto.request;
+
+import java.util.UUID;
+
+public record UpdateProfileImgUrlRequestDto(
+        UUID userId,
+        String profileImgUrl
+) {
+}

--- a/src/main/java/com/somemore/user/service/UpdateProfileImgUrlService.java
+++ b/src/main/java/com/somemore/user/service/UpdateProfileImgUrlService.java
@@ -1,0 +1,25 @@
+package com.somemore.user.service;
+
+import com.somemore.user.domain.UserCommonAttribute;
+import com.somemore.user.dto.request.UpdateProfileImgUrlRequestDto;
+import com.somemore.user.usecase.UpdateProfileImgUrlUseCase;
+import com.somemore.user.usecase.UserQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class UpdateProfileImgUrlService implements UpdateProfileImgUrlUseCase {
+
+    private final UserQueryUseCase userQueryUseCase;
+
+    @Override
+    public void updateProfileImgUrl(UpdateProfileImgUrlRequestDto updateProfileImgUrlRequestDto) {
+        UserCommonAttribute userCommonAttribute =
+                userQueryUseCase.getCommonAttributeByUserId(updateProfileImgUrlRequestDto.userId());
+
+        userCommonAttribute.updateImgUrl(updateProfileImgUrlRequestDto.profileImgUrl());
+    }
+}

--- a/src/main/java/com/somemore/user/usecase/UpdateProfileImgUrlUseCase.java
+++ b/src/main/java/com/somemore/user/usecase/UpdateProfileImgUrlUseCase.java
@@ -1,0 +1,7 @@
+package com.somemore.user.usecase;
+
+import com.somemore.user.dto.request.UpdateProfileImgUrlRequestDto;
+
+public interface UpdateProfileImgUrlUseCase {
+    void updateProfileImgUrl(UpdateProfileImgUrlRequestDto updateProfileImgUrlRequestDto);
+}

--- a/src/test/java/com/somemore/center/controller/CenterCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/center/controller/CenterCommandApiControllerTest.java
@@ -1,0 +1,51 @@
+package com.somemore.center.controller;
+
+import com.somemore.center.dto.request.CenterProfileImgUpdateRequestDto;
+import com.somemore.center.usecase.UpdateCenterProfileImgUseCase;
+import com.somemore.support.ControllerTestSupport;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+class CenterCommandApiControllerTest extends ControllerTestSupport {
+
+    @MockBean
+    private UpdateCenterProfileImgUseCase updateCenterProfileImgUseCase;
+
+    @DisplayName("기관 프로필 이미지를 수정할 수 있다. (controller)")
+    @Test
+    void updateCenterProfile() throws Exception {
+
+        // given
+        UUID centerId = UUID.randomUUID();
+        CenterProfileImgUpdateRequestDto requestDto = new CenterProfileImgUpdateRequestDto("test.jpg");
+
+        String expectedPresignedUrl = "https://example.com/presigned-url/test.jpg";
+        when(updateCenterProfileImgUseCase.updateCenterProfileImg(centerId, requestDto))
+                .thenReturn(expectedPresignedUrl);
+
+        // when & then
+        mockMvc.perform(
+                        put("/api/center/profileImgUpdate")
+                                .header("X-User-Id", centerId.toString()) // @UserId를 시뮬레이션
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestDto))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("센터 프로필 수정 성공"))
+                .andExpect(jsonPath("$.data").value(expectedPresignedUrl));
+
+        verify(updateCenterProfileImgUseCase, times(1)).updateCenterProfileImg(centerId, requestDto);
+    }
+
+}

--- a/src/test/java/com/somemore/center/service/UpdateCenterProfileImgServiceTest.java
+++ b/src/test/java/com/somemore/center/service/UpdateCenterProfileImgServiceTest.java
@@ -1,0 +1,67 @@
+package com.somemore.center.service;
+
+import com.somemore.center.domain.NEWCenter;
+import com.somemore.center.dto.request.CenterProfileImgUpdateRequestDto;
+import com.somemore.center.repository.NEWCenterRepository;
+import com.somemore.global.imageupload.usecase.ImageUploadUseCase;
+import com.somemore.support.IntegrationTestSupport;
+import com.somemore.user.domain.UserCommonAttribute;
+import com.somemore.user.repository.usercommonattribute.UserCommonAttributeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.somemore.user.domain.UserRole.CENTER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class UpdateCenterProfileImgServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UpdateCenterProfileImgService updateCenterProfileImgService;
+
+    @Autowired
+    private ImageUploadUseCase imageUploadUseCase;
+
+    @Autowired
+    private NEWCenterRepository centerRepository;
+
+    @Autowired
+    private UserCommonAttributeRepository userCommonAttributeRepository;
+
+    @DisplayName("파일명을 받아 기관 프로필 이미지의 presignedUrl을 발급해준다.")
+    @Test
+    void updateCenterProfileImg() {
+
+        //given
+        UUID userId = UUID.randomUUID();
+
+        NEWCenter center = NEWCenter.createDefault(userId);
+        centerRepository.save(center);
+        UUID centerId = center.getId();
+
+        UserCommonAttribute userCommonAttribute = UserCommonAttribute.createDefault(userId, CENTER);
+        userCommonAttributeRepository.save(userCommonAttribute);
+
+        CenterProfileImgUpdateRequestDto requestDto = new CenterProfileImgUpdateRequestDto("test.png");
+
+        //when
+        String presignedUrl = updateCenterProfileImgService.updateCenterProfileImg(centerId, requestDto);
+
+        //then
+        assertThat(presignedUrl).isNotNull();
+
+        Optional<UserCommonAttribute> updatedUserCommonAttribute = userCommonAttributeRepository.findByUserId(userId);
+        assertThat(updatedUserCommonAttribute)
+                .isNotNull();
+        assertTrue(updatedUserCommonAttribute.get().getImgUrl().contains(requestDto.fileName()));
+
+    }
+
+
+}

--- a/src/test/java/com/somemore/domains/center/controller/PreferItemCommandApiControllerTest.java
+++ b/src/test/java/com/somemore/domains/center/controller/PreferItemCommandApiControllerTest.java
@@ -3,6 +3,7 @@ package com.somemore.domains.center.controller;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,12 +15,11 @@ import com.somemore.domains.center.usecase.command.CreatePreferItemUseCase;
 import com.somemore.domains.center.usecase.command.DeletePreferItemUseCase;
 import com.somemore.global.exception.BadRequestException;
 import com.somemore.support.ControllerTestSupport;
-import com.somemore.support.annotation.WithMockCustomUser;
+import com.somemore.support.annotation.MockUser;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 
 class PreferItemCommandApiControllerTest extends ControllerTestSupport {
 
@@ -32,25 +32,25 @@ class PreferItemCommandApiControllerTest extends ControllerTestSupport {
 
     @DisplayName("기관은 선호물품을 등록할 수 있다. (controller)")
     @Test
-    @WithMockCustomUser(role = "CENTER")
+    @MockUser(role = "ROLE_CENTER")
     void registerPreferItem() throws Exception {
         // given
-        UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000"); // 고정된 UUID 사용
+        UUID centerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         PreferItemCreateRequestDto requestDto = new PreferItemCreateRequestDto("어린이 도서");
         PreferItemCreateResponseDto responseDto = new PreferItemCreateResponseDto(
                 1L,
-                userId,
+                centerId,
                 "어린이 도서"
         );
 
-        given(createPreferItemUseCase.createPreferItem(userId, requestDto))
+        given(createPreferItemUseCase.createPreferItem(centerId, requestDto))
                 .willReturn(responseDto);
 
         // when & then
         mockMvc.perform(post("/api/preferItem")
-                        .contentType(MediaType.APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))
-                        .principal(() -> userId.toString()))
+                        .header("Authorization", "Bearer access-token"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("관심 기관 등록 성공"))
@@ -59,95 +59,95 @@ class PreferItemCommandApiControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.item_name").value(responseDto.itemName()));
 
         // verify
-        verify(createPreferItemUseCase).createPreferItem(userId, requestDto);
+        verify(createPreferItemUseCase).createPreferItem(centerId, requestDto);
     }
 
     @DisplayName("존재하지 않는 기관 ID로 선호물품을 등록할 수 없다. (controller)")
     @Test
-    @WithMockCustomUser(role = "CENTER")
+    @MockUser(role = "ROLE_CENTER")
     void registerPreferItem_Fail_WhenCenterNotExists() throws Exception {
         // given
-        UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UUID centerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         PreferItemCreateRequestDto requestDto = new PreferItemCreateRequestDto("어린이 도서");
 
-        given(createPreferItemUseCase.createPreferItem(userId, requestDto))
+        given(createPreferItemUseCase.createPreferItem(centerId, requestDto))
                 .willThrow(new BadRequestException("존재하지 않는 기관입니다."));
 
         // when & then
         mockMvc.perform(post("/api/preferItem")
-                        .contentType(MediaType.APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto))
-                        .principal(() -> userId.toString()))
+                        .header("Authorization", "Bearer access-token"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.detail").value("존재하지 않는 기관입니다."));
 
         // verify
-        verify(createPreferItemUseCase).createPreferItem(userId, requestDto);
+        verify(createPreferItemUseCase).createPreferItem(centerId, requestDto);
     }
 
     @DisplayName("기관은 등록한 선호물품을 삭제할 수 있다. (controller)")
     @Test
-    @WithMockCustomUser(role = "CENTER")
+    @MockUser(role = "ROLE_CENTER")
     void deletePreferItem() throws Exception {
         // given
-        UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UUID centerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         Long preferItemId = 1L;
 
         // when & then
         mockMvc.perform(delete("/api/preferItem/{preferItemId}", preferItemId)
-                        .principal(userId::toString))
+                        .principal(centerId::toString))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("선호 물품 삭제 성공"));
 
         // verify
-        verify(deletePreferItemUseCase).deletePreferItem(userId, preferItemId);
+        verify(deletePreferItemUseCase).deletePreferItem(centerId, preferItemId);
     }
 
     @DisplayName("선호물품을 등록한 기관이 아니라면 선호물품을 삭제할 수 없다. (controller)")
     @Test
-    @WithMockCustomUser(role = "CENTER")
+    @MockUser(role = "ROLE_CENTER")
     void deletePreferItem_Fail_WhenUnauthorized() throws Exception {
         // given
-        UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UUID centerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         Long preferItemId = 1L;
 
         doThrow(new BadRequestException("다른 기관의 선호 물품은 삭제할 수 없습니다."))
                 .when(deletePreferItemUseCase)
-                .deletePreferItem(userId, preferItemId);
+                .deletePreferItem(centerId, preferItemId);
 
         // when & then
         mockMvc.perform(delete("/api/preferItem/{preferItemId}", preferItemId)
-                        .principal(userId::toString))
+                        .principal(centerId::toString))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.detail").value("다른 기관의 선호 물품은 삭제할 수 없습니다."));
 
         // verify
-        verify(deletePreferItemUseCase).deletePreferItem(userId, preferItemId);
+        verify(deletePreferItemUseCase).deletePreferItem(centerId, preferItemId);
     }
 
     @DisplayName("존재하지 않는 선호물품을 삭제할 수 없다. (controller)")
     @Test
-    @WithMockCustomUser(role = "CENTER")
+    @MockUser(role = "ROLE_CENTER")
     void deletePreferItem_Fail_WhenPreferItemNotExists() throws Exception {
         // given
-        UUID userId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UUID centerId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         Long preferItemId = 1L;
 
         doThrow(new BadRequestException("존재하지 않는 선호 물품입니다."))
                 .when(deletePreferItemUseCase)
-                .deletePreferItem(userId, preferItemId);
+                .deletePreferItem(centerId, preferItemId);
 
         // when & then
         mockMvc.perform(delete("/api/preferItem/{preferItemId}", preferItemId)
-                        .principal(userId::toString))
+                        .principal(centerId::toString))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.detail").value("존재하지 않는 선호 물품입니다."));
 
         // verify
-        verify(deletePreferItemUseCase).deletePreferItem(userId, preferItemId);
+        verify(deletePreferItemUseCase).deletePreferItem(centerId, preferItemId);
     }
 }

--- a/src/test/java/com/somemore/user/service/UpdateProfileImgUrlServiceTest.java
+++ b/src/test/java/com/somemore/user/service/UpdateProfileImgUrlServiceTest.java
@@ -1,0 +1,55 @@
+package com.somemore.user.service;
+
+import com.somemore.support.IntegrationTestSupport;
+import com.somemore.user.domain.UserCommonAttribute;
+import com.somemore.user.dto.request.UpdateProfileImgUrlRequestDto;
+import com.somemore.user.repository.usercommonattribute.UserCommonAttributeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+
+import static com.somemore.user.domain.UserRole.CENTER;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UpdateProfileImgUrlServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UpdateProfileImgUrlService updateProfileImgUrlService;
+
+    @Autowired
+    private UserQueryService userQueryService;
+
+    @Autowired
+    private UserCommonAttributeRepository commonAttributeRepository;
+
+    @DisplayName("프로필 이미지 링크를 업데이트 할 수 있다.")
+    @Test
+    void updateProfileImgUrl() {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        UserCommonAttribute userCommonAttribute = UserCommonAttribute.createDefault(userId, CENTER);
+        commonAttributeRepository.save(userCommonAttribute);
+
+        String profileImgUrl = "https://example.com/new_profile.jpg";
+
+        UpdateProfileImgUrlRequestDto requestDto = new UpdateProfileImgUrlRequestDto(userId, profileImgUrl);
+
+        // when
+        updateProfileImgUrlService.updateProfileImgUrl(requestDto);
+
+        // then
+        UserCommonAttribute updatedUserCommonAttribute = userQueryService.getCommonAttributeByUserId(userId);
+
+        assertEquals(profileImgUrl, updatedUserCommonAttribute.getImgUrl());
+
+        assertEquals(userCommonAttribute.getName(), updatedUserCommonAttribute.getName());
+        assertEquals(userCommonAttribute.getContactNumber(), updatedUserCommonAttribute.getContactNumber());
+        assertEquals(userCommonAttribute.getIntroduce(), updatedUserCommonAttribute.getIntroduce());
+        assertEquals(userCommonAttribute.isCustomized(), updatedUserCommonAttribute.isCustomized());
+    }
+
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
- #339  <!-- 관련된 이슈를 적어주세요 #이슈번호 -->
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

이미지 업로드 방식이 presigned 방식으로 변경됨에 따라
기관 프로필 이미지 업데이트 api를 리팩토링했습니다.
프론트에서의 에러가 우려되어 기존 이용하던 기능은 그대로 두었습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 유저 공통속성 엔티티에 imgUrl 상태 변경 메서드 추가
- 유저 공통속성의 프로필 이미지 url 변경 유스케이스 생성
- 기관 도메인에 프로필 이미지 업데이트 유스케이스 구현
- 기관 프로필 이미지 업데이트 엔드포인트 추가

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
